### PR TITLE
Codeformatting with black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - TWINE_USERNAME=geostatframework
     - CIBW_BEFORE_BUILD="pip install numpy==1.17.3 scipy==1.3.2 cython==0.29.14 setuptools"
-    - CIBW_TEST_REQUIRES="pytest scikit-learn"
+    - CIBW_TEST_REQUIRES="pytest scikit-learn gstools"
     - CIBW_TEST_COMMAND="pytest -v {project}/tests"
 
 before_install:
@@ -21,9 +21,9 @@ before_install:
         ln -s /c/Python38/python.exe /c/Python38/python3.exe
     fi
 
-script:
-  - python3 -m pip install cibuildwheel==1.3.0
-  - python3 -m cibuildwheel --output-dir dist
+install: python3 -m pip install cibuildwheel==1.3.0
+
+script: python3 -m cibuildwheel --output-dir dist
 
 after_success:
   - |
@@ -40,12 +40,20 @@ notifications:
 
 jobs:
   include:
+    - name: "black check"
+      services: docker
+      install: python3 -m pip install black
+      script: python3 -m black --check pykrige/ examples/ tests/
+      after_success: echo "all files formatted correctly"
+      after_failure: echo "some files not formatted correctly"
+
     - name: "sdist and coverage"
       services: docker
-      script:
-        - python3 -m pip install -U setuptools pytest-cov coveralls scikit-learn
-        - python3 -m pip install -U numpy==1.17.3 cython==0.29.14
+      install:
+        - python3 -m pip install -r requirements_setup.txt
+        - python3 -m pip install -r requirements_test.txt
         - python3 -m pip install -r requirements.txt
+      script:
         - python3 setup.py sdist -d dist
         - python3 setup.py build_ext --inplace
         - python3 -m pytest --cov pykrige --cov-report term-missing -v tests/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@ import os
 import shlex
 import sphinx_rtd_theme
 import matplotlib
+
 matplotlib.use("Agg")
 
 
@@ -61,9 +62,9 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 source_suffix = {
-    '.rst': 'restructuredtext',
-    '.txt': 'restructuredtext',
-    '.md': 'markdown',
+    ".rst": "restructuredtext",
+    ".txt": "restructuredtext",
+    ".md": "markdown",
 }
 
 # The encoding of source files.
@@ -258,13 +259,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (
-        master_doc,
-        "PyKrige.tex",
-        "PyKrige Documentation",
-        "PyKrige developers",
-        "manual",
-    )
+    (master_doc, "PyKrige.tex", "PyKrige Documentation", "PyKrige developers", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/source/sphinxext/github_link.py
+++ b/docs/source/sphinxext/github_link.py
@@ -60,16 +60,12 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
     if not fn:
         return
 
-    fn = os.path.relpath(
-        fn, start=os.path.dirname(__import__(package).__file__)
-    )
+    fn = os.path.relpath(fn, start=os.path.dirname(__import__(package).__file__))
     try:
         lineno = inspect.getsourcelines(obj)[1]
     except Exception:
         lineno = ""
-    return url_fmt.format(
-        revision=revision, package=package, path=fn, lineno=lineno
-    )
+    return url_fmt.format(revision=revision, package=package, path=fn, lineno=lineno)
 
 
 def make_linkcode_resolve(package, url_fmt):

--- a/examples/gstools_covmodel.py
+++ b/examples/gstools_covmodel.py
@@ -10,32 +10,34 @@ import os
 import numpy as np
 from pykrige.ok import OrdinaryKriging
 from matplotlib import pyplot as plt
+
 try:
     from gstools import Gaussian
+
     GS_IMP = True
 except ImportError:
     GS_IMP = False
 
 # conditioning data
-data = np.array([[0.3, 1.2, 0.47],
-                 [1.9, 0.6, 0.56],
-                 [1.1, 3.2, 0.74],
-                 [3.3, 4.4, 1.47],
-                 [4.7, 3.8, 1.74]])
+data = np.array(
+    [
+        [0.3, 1.2, 0.47],
+        [1.9, 0.6, 0.56],
+        [1.1, 3.2, 0.74],
+        [3.3, 4.4, 1.47],
+        [4.7, 3.8, 1.74],
+    ]
+)
 # grid definition for output field
 gridx = np.arange(0.0, 5.5, 0.1)
 gridy = np.arange(0.0, 6.5, 0.1)
 # a GSTools based covariance model
 if GS_IMP:
-    cov_model = Gaussian(
-        dim=2, len_scale=4, anis=.2, angles=-.5, var=.5, nugget=.1
-    )
+    cov_model = Gaussian(dim=2, len_scale=4, anis=0.2, angles=-0.5, var=0.5, nugget=0.1)
 else:
     cov_model = "gaussian"
 # ordinary kriging with pykrige
 OK1 = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], cov_model)
-z1, ss1 = OK1.execute('grid', gridx, gridy)
+z1, ss1 = OK1.execute("grid", gridx, gridy)
 plt.imshow(z1, origin="lower")
-if 'CI' not in os.environ:
-    # skip in continous integration
-    plt.show()
+plt.show()

--- a/examples/krige_cv.py
+++ b/examples/krige_cv.py
@@ -13,11 +13,12 @@ from pykrige.compat import GridSearchCV
 
 # 2D Kring param opt
 
-param_dict = {"method": ["ordinary", "universal"],
-              "variogram_model": ["linear", "power", "gaussian", "spherical"],
-              # "nlags": [4, 6, 8],
-              # "weight": [True, False]
-              }
+param_dict = {
+    "method": ["ordinary", "universal"],
+    "variogram_model": ["linear", "power", "gaussian", "spherical"],
+    # "nlags": [4, 6, 8],
+    # "weight": [True, False]
+}
 
 estimator = GridSearchCV(Krige(), param_dict, verbose=True)
 
@@ -29,23 +30,28 @@ y = 5 * np.random.rand(100)
 estimator.fit(X=X, y=y)
 
 
-if hasattr(estimator, 'best_score_'):
-    print('best_score R² = {:.3f}'.format(estimator.best_score_))
-    print('best_params = ', estimator.best_params_)
+if hasattr(estimator, "best_score_"):
+    print("best_score R² = {:.3f}".format(estimator.best_score_))
+    print("best_params = ", estimator.best_params_)
 
-print('\nCV results::')
-if hasattr(estimator, 'cv_results_'):
-    for key in ['mean_test_score', 'mean_train_score',
-                'param_method', 'param_variogram_model']:
-        print(' - {} : {}'.format(key, estimator.cv_results_[key]))
+print("\nCV results::")
+if hasattr(estimator, "cv_results_"):
+    for key in [
+        "mean_test_score",
+        "mean_train_score",
+        "param_method",
+        "param_variogram_model",
+    ]:
+        print(" - {} : {}".format(key, estimator.cv_results_[key]))
 
 # 3D Kring param opt
 
-param_dict3d = {"method": ["ordinary3d", "universal3d"],
-              "variogram_model": ["linear", "power", "gaussian", "spherical"],
-              # "nlags": [4, 6, 8],
-              # "weight": [True, False]
-              }
+param_dict3d = {
+    "method": ["ordinary3d", "universal3d"],
+    "variogram_model": ["linear", "power", "gaussian", "spherical"],
+    # "nlags": [4, 6, 8],
+    # "weight": [True, False]
+}
 
 estimator = GridSearchCV(Krige(), param_dict3d, verbose=True)
 
@@ -57,12 +63,16 @@ y = 5 * np.random.rand(100)
 estimator.fit(X=X3, y=y)
 
 
-if hasattr(estimator, 'best_score_'):
-    print('best_score R² = {:.3f}'.format(estimator.best_score_))
-    print('best_params = ', estimator.best_params_)
+if hasattr(estimator, "best_score_"):
+    print("best_score R² = {:.3f}".format(estimator.best_score_))
+    print("best_params = ", estimator.best_params_)
 
-print('\nCV results::')
-if hasattr(estimator, 'cv_results_'):
-    for key in ['mean_test_score', 'mean_train_score',
-                'param_method', 'param_variogram_model']:
-        print(' - {} : {}'.format(key, estimator.cv_results_[key]))
+print("\nCV results::")
+if hasattr(estimator, "cv_results_"):
+    for key in [
+        "mean_test_score",
+        "mean_train_score",
+        "param_method",
+        "param_variogram_model",
+    ]:
+        print(" - {} : {}".format(key, estimator.cv_results_[key]))

--- a/examples/krige_geometric.py
+++ b/examples/krige_geometric.py
@@ -17,42 +17,50 @@ np.random.seed(89239413)
 # of nodes and a uniform distribution of values in the interval
 # [2.0, 5.5]:
 N = 7
-lon = 360.0*np.random.random(N)
-lat = 180.0/np.pi*np.arcsin(2*np.random.random(N)-1)
-z   = 3.5*np.random.rand(N) + 2.0
+lon = 360.0 * np.random.random(N)
+lat = 180.0 / np.pi * np.arcsin(2 * np.random.random(N) - 1)
+z = 3.5 * np.random.rand(N) + 2.0
 
 # Generate a regular grid with 60° longitude and 30° latitude steps:
 grid_lon = np.linspace(0.0, 360.0, 7)
 grid_lat = np.linspace(-90.0, 90.0, 7)
 
 # Create ordinary kriging object:
-OK = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                     enable_plotting=False, coordinates_type='geographic')
+OK = OrdinaryKriging(
+    lon,
+    lat,
+    z,
+    variogram_model="linear",
+    verbose=False,
+    enable_plotting=False,
+    coordinates_type="geographic",
+)
 
 # Execute on grid:
-z1, ss1 = OK.execute('grid', grid_lon, grid_lat)
+z1, ss1 = OK.execute("grid", grid_lon, grid_lat)
 
 # Create ordinary kriging object ignoring curvature:
-OK = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                     enable_plotting=False)
+OK = OrdinaryKriging(
+    lon, lat, z, variogram_model="linear", verbose=False, enable_plotting=False
+)
 
 # Execute on grid:
-z2, ss2 = OK.execute('grid', grid_lon, grid_lat)
+z2, ss2 = OK.execute("grid", grid_lon, grid_lat)
 
 # Print data at equator (last longitude index will show periodicity):
 print("Original data:")
-print("Longitude:",lon.astype(int))
-print("Latitude: ",lat.astype(int))
-print("z:        ",np.array_str(z, precision=2))
+print("Longitude:", lon.astype(int))
+print("Latitude: ", lat.astype(int))
+print("z:        ", np.array_str(z, precision=2))
 print("\nKrige at 60° latitude:\n======================")
-print("Longitude:",grid_lon)
-print("Value:    ",np.array_str(z1[5,:], precision=2))
-print("Sigma²:   ",np.array_str(ss1[5,:], precision=2))
+print("Longitude:", grid_lon)
+print("Value:    ", np.array_str(z1[5, :], precision=2))
+print("Sigma²:   ", np.array_str(ss1[5, :], precision=2))
 print("\nIgnoring curvature:\n=====================")
-print("Value:    ",np.array_str(z2[5,:], precision=2))
-print("Sigma²:   ",np.array_str(ss2[5,:], precision=2))
+print("Value:    ", np.array_str(z2[5, :], precision=2))
+print("Sigma²:   ", np.array_str(ss2[5, :], precision=2))
 
-##====================================OUTPUT==================================
+# ====================================OUTPUT==================================
 # >>> Original data:
 # >>> Longitude: [122 166  92 138  86 122 136]
 # >>> Latitude:  [-46 -36 -25 -73 -25  50 -29]

--- a/examples/kriging_1D.py
+++ b/examples/kriging_1D.py
@@ -8,12 +8,14 @@ import os
 
 import numpy as np
 import matplotlib.pyplot as plt
+from pykrige import OrdinaryKriging
 
-plt.style.use('ggplot')
+plt.style.use("ggplot")
 
-# Data taken from https://blog.dominodatalab.com/fitting-gaussian-process-models-python/
-
-X, y = np.array([[-5.01, 1.06], [-4.90, 0.92], [-4.82, 0.35], [-4.69, 0.49], [-4.56, 0.52], 
+# Data taken from
+# https://blog.dominodatalab.com/fitting-gaussian-process-models-python/
+X, y = np.array([
+     [-5.01, 1.06], [-4.90, 0.92], [-4.82, 0.35], [-4.69, 0.49], [-4.56, 0.52],
      [-4.52, 0.12], [-4.39, 0.47], [-4.32,-0.19], [-4.19, 0.08], [-4.11,-0.19],
      [-4.00,-0.03], [-3.89,-0.03], [-3.78,-0.05], [-3.67, 0.10], [-3.59, 0.44],
      [-3.50, 0.66], [-3.39,-0.12], [-3.28, 0.45], [-3.20, 0.14], [-3.07,-0.28],
@@ -33,33 +35,35 @@ X, y = np.array([[-5.01, 1.06], [-4.90, 0.92], [-4.82, 0.35], [-4.69, 0.49], [-4
      [3.52 ,-0.55], [3.63 ,-0.92], [3.72 ,-0.76], [3.80 ,-0.41], [3.91 , 0.12],
      [4.04 , 0.25], [4.13 , 0.16], [4.24 , 0.26], [4.32 , 0.62], [4.44 , 1.69],
      [4.52 , 1.11], [4.65 , 0.36], [4.74 , 0.79], [4.84 , 0.87], [4.93 , 1.01],
-     [5.02 , 0.55]]).T
-
-
-from pykrige import OrdinaryKriging
+     [5.02 , 0.55]
+]).T
 
 X_pred = np.linspace(-6, 6, 200)
 
 # pykrige doesn't support 1D data for now, only 2D or 3D
 # adapting the 1D input to 2D
-uk = OrdinaryKriging(X, np.zeros(X.shape), y, variogram_model='gaussian',)
+uk = OrdinaryKriging(X, np.zeros(X.shape), y, variogram_model="gaussian")
 
-y_pred, y_std = uk.execute('grid', X_pred, np.array([0.]))
+y_pred, y_std = uk.execute("grid", X_pred, np.array([0.0]))
 
 y_pred = np.squeeze(y_pred)
 y_std = np.squeeze(y_std)
 
 fig, ax = plt.subplots(1, 1, figsize=(10, 4))
-ax.scatter(X, y, s=40, label='Input data')
+ax.scatter(X, y, s=40, label="Input data")
 
 
-ax.plot(X_pred, y_pred, label='Predicted values')
-ax.fill_between(X_pred, y_pred - 3*y_std, y_pred + 3*y_std, alpha=0.3, label='Confidence interval')
+ax.plot(X_pred, y_pred, label="Predicted values")
+ax.fill_between(
+    X_pred,
+    y_pred - 3 * y_std,
+    y_pred + 3 * y_std,
+    alpha=0.3,
+    label="Confidence interval",
+)
 ax.legend(loc=9)
-ax.set_xlabel('x')
-ax.set_ylabel('y')
+ax.set_xlabel("x")
+ax.set_ylabel("y")
 ax.set_xlim(-6, 6)
 ax.set_ylim(-2.8, 3.5)
-if 'CI' not in os.environ:
-    # skip in continous integration
-    plt.show()
+plt.show()

--- a/examples/kriging_1D.py
+++ b/examples/kriging_1D.py
@@ -12,6 +12,7 @@ from pykrige import OrdinaryKriging
 
 plt.style.use("ggplot")
 
+# fmt: off
 # Data taken from
 # https://blog.dominodatalab.com/fitting-gaussian-process-models-python/
 X, y = np.array([
@@ -37,6 +38,7 @@ X, y = np.array([
      [4.52 , 1.11], [4.65 , 0.36], [4.74 , 0.79], [4.84 , 0.87], [4.93 , 1.01],
      [5.02 , 0.55]
 ]).T
+# fmt: on
 
 X_pred = np.linspace(-6, 6, 200)
 

--- a/examples/regression_kriging2d.py
+++ b/examples/regression_kriging2d.py
@@ -27,22 +27,23 @@ except PermissionError:
     sys.exit(0)
 
 # take the first 5000 as Kriging is memory intensive
-p = housing['data'][:5000, :-2]
-x = housing['data'][:5000, -2:]
-target = housing['target'][:5000]
+p = housing["data"][:5000, :-2]
+x = housing["data"][:5000, -2:]
+target = housing["target"][:5000]
 
-p_train, p_test, x_train, x_test, target_train, target_test \
-    = train_test_split(p, x, target, test_size=0.3, random_state=42)
+p_train, p_test, x_train, x_test, target_train, target_test = train_test_split(
+    p, x, target, test_size=0.3, random_state=42
+)
 
 for m in models:
-    print('=' * 40)
-    print('regression model:', m.__class__.__name__)
+    print("=" * 40)
+    print("regression model:", m.__class__.__name__)
     m_rk = RegressionKriging(regression_model=m, n_closest_points=10)
     m_rk.fit(p_train, x_train, target_train)
-    print('Regression Score: ', m_rk.regression_model.score(p_test, target_test))
-    print('RK score: ', m_rk.score(p_test, x_test, target_test))
+    print("Regression Score: ", m_rk.regression_model.score(p_test, target_test))
+    print("RK score: ", m_rk.score(p_test, x_test, target_test))
 
-##====================================OUTPUT==================================
+# ====================================OUTPUT==================================
 
 # ========================================
 #  regression model: <class 'sklearn.svm.classes.SVR'>

--- a/pykrige/__init__.py
+++ b/pykrige/__init__.py
@@ -38,7 +38,7 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistics: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 
 from . import kriging_tools as kt  # noqa
@@ -54,11 +54,11 @@ except ImportError:  # pragma: nocover
     __version__ = "0.0.0.dev0"
 
 
-__author__ = 'Benjamin S. Murphy'
+__author__ = "Benjamin S. Murphy"
 
 
 __all__ = ["__version__"]
-__all__ += ["kt", 'ok', 'uk', 'ok3d', 'uk3d', 'kriging_tools']
+__all__ += ["kt", "ok", "uk", "ok3d", "uk3d", "kriging_tools"]
 __all__ += ["OrdinaryKriging"]
 __all__ += ["UniversalKriging"]
 __all__ += ["OrdinaryKriging3D"]

--- a/pykrige/compat.py
+++ b/pykrige/compat.py
@@ -26,5 +26,6 @@ class SklearnException(Exception):
 
 def validate_sklearn():
     if not SKLEARN_INSTALLED:
-        raise SklearnException('sklearn needs to be installed in order '
-                               'to use this module')
+        raise SklearnException(
+            "sklearn needs to be installed in order " "to use this module"
+        )

--- a/pykrige/compat.py
+++ b/pykrige/compat.py
@@ -15,6 +15,8 @@ try:
     # https://stackoverflow.com/a/56618067/6696397
     if "return_train_score" in arg_spec:
         GridSearchCV = partial(GridSearchCV, return_train_score=True)
+    if "iid" in arg_spec:
+        GridSearchCV = partial(GridSearchCV, iid=False)
 
 except ImportError:
     SKLEARN_INSTALLED = False

--- a/pykrige/compat.py
+++ b/pykrige/compat.py
@@ -27,5 +27,5 @@ class SklearnException(Exception):
 def validate_sklearn():
     if not SKLEARN_INSTALLED:
         raise SklearnException(
-            "sklearn needs to be installed in order " "to use this module"
+            "sklearn needs to be installed in order to use this module"
         )

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -180,7 +180,7 @@ def _adjust_for_anisotropy(X, center, scaling, angle):
         rot_tot = np.dot(rotate_z, np.dot(rotate_y, rotate_x))
     else:
         raise ValueError(
-            "Adjust for anisotropy function doesn't " "support ND spaces where N>3"
+            "Adjust for anisotropy function doesn't support ND spaces where N>3"
         )
     X_adj = np.dot(stretch, np.dot(rot_tot, X.T)).T
 
@@ -462,7 +462,7 @@ def _initialize_variogram_model(
     elif coordinates_type == "geographic":
         if X.shape[1] != 2:
             raise ValueError(
-                "Geographic coordinate type only " "supported for 2D datasets."
+                "Geographic coordinate type only supported for 2D datasets."
             )
         x1, x2 = np.meshgrid(X[:, 0], X[:, 0], sparse=True)
         y1, y2 = np.meshgrid(X[:, 1], X[:, 1], sparse=True)
@@ -475,7 +475,7 @@ def _initialize_variogram_model(
 
     else:
         raise ValueError(
-            "Specified coordinate type '%s' " "is not supported." % coordinates_type
+            "Specified coordinate type '%s' is not supported." % coordinates_type
         )
 
     # Equal-sized bins are now implemented. The upper limit on the bins
@@ -532,7 +532,7 @@ def _initialize_variogram_model(
     if variogram_model_parameters is not None:
         if variogram_model == "linear" and len(variogram_model_parameters) != 2:
             raise ValueError(
-                "Exactly two parameters required " "for linear variogram model."
+                "Exactly two parameters required for linear variogram model."
             )
         elif (
             variogram_model
@@ -730,7 +730,7 @@ def _krige(
     # this check is done when initializing variogram, but kept here anyways...
     else:
         raise ValueError(
-            "Specified coordinate type '%s' " "is not supported." % coordinates_type
+            "Specified coordinate type '%s' is not supported." % coordinates_type
         )
 
     # check if kriging point overlaps with measurement point

--- a/pykrige/kriging_tools.py
+++ b/pykrige/kriging_tools.py
@@ -49,7 +49,7 @@ def write_asc_grid(x, y, z, filename="output.asc", style=1):
     ncols = z.shape[1]
 
     if z.ndim != 2:
-        raise ValueError("Two-dimensional grid is required to " "write *.asc grid.")
+        raise ValueError("Two-dimensional grid is required to write *.asc grid.")
     if x.ndim > 1 or y.ndim > 1:
         raise ValueError(
             "Dimensions of X and/or Y coordinate arrays are not "
@@ -75,7 +75,7 @@ def write_asc_grid(x, y, z, filename="output.asc", style=1):
         or abs((y[-1] - y[0]) / (y.shape[0] - 1)) != dy
     ):
         raise ValueError(
-            "X or Y spacing is not constant; *.asc " "grid cannot be written."
+            "X or Y spacing is not constant; *.asc grid cannot be written."
         )
     cellsize = -1
     if style == 2:

--- a/pykrige/kriging_tools.py
+++ b/pykrige/kriging_tools.py
@@ -10,14 +10,14 @@ Summary
 -------
 Methods for reading/writing ASCII grid files.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 import numpy as np
 import warnings
 import io
 
 
-def write_asc_grid(x, y, z, filename='output.asc', style=1):
+def write_asc_grid(x, y, z, filename="output.asc", style=1):
     r"""Writes gridded data to ASCII grid file (\*.asc).
 
     This is useful for exporting data to a GIS program.
@@ -40,7 +40,7 @@ def write_asc_grid(x, y, z, filename='output.asc', style=1):
     """
 
     if np.ma.is_masked(z):
-        z = np.array(z.tolist(-999.))
+        z = np.array(z.tolist(-999.0))
 
     x = np.squeeze(np.array(x))
     y = np.squeeze(np.array(y))
@@ -49,31 +49,41 @@ def write_asc_grid(x, y, z, filename='output.asc', style=1):
     ncols = z.shape[1]
 
     if z.ndim != 2:
-        raise ValueError("Two-dimensional grid is required to "
-                         "write *.asc grid.")
+        raise ValueError("Two-dimensional grid is required to " "write *.asc grid.")
     if x.ndim > 1 or y.ndim > 1:
-        raise ValueError("Dimensions of X and/or Y coordinate arrays are not "
-                         "as expected. Could not write *.asc grid.")
+        raise ValueError(
+            "Dimensions of X and/or Y coordinate arrays are not "
+            "as expected. Could not write *.asc grid."
+        )
     if z.shape != (y.size, x.size):
-        warnings.warn("Grid dimensions are not as expected. "
-                      "Incorrect *.asc file generation may result.",
-                      RuntimeWarning)
+        warnings.warn(
+            "Grid dimensions are not as expected. "
+            "Incorrect *.asc file generation may result.",
+            RuntimeWarning,
+        )
     if np.amin(x) != x[0] or np.amin(y) != y[0]:
-        warnings.warn("Order of X or Y coordinates is not as expected. "
-                      "Incorrect *.asc file generation may result.",
-                      RuntimeWarning)
+        warnings.warn(
+            "Order of X or Y coordinates is not as expected. "
+            "Incorrect *.asc file generation may result.",
+            RuntimeWarning,
+        )
 
     dx = abs(x[1] - x[0])
     dy = abs(y[1] - y[0])
-    if abs((x[-1] - x[0])/(x.shape[0] - 1)) != dx or \
-       abs((y[-1] - y[0])/(y.shape[0] - 1)) != dy:
-        raise ValueError("X or Y spacing is not constant; *.asc "
-                         "grid cannot be written.")
+    if (
+        abs((x[-1] - x[0]) / (x.shape[0] - 1)) != dx
+        or abs((y[-1] - y[0]) / (y.shape[0] - 1)) != dy
+    ):
+        raise ValueError(
+            "X or Y spacing is not constant; *.asc " "grid cannot be written."
+        )
     cellsize = -1
     if style == 2:
         if dx != dy:
-            raise ValueError("X and Y spacing is not the same. "
-                             "Cannot write *.asc file in the specified format.")
+            raise ValueError(
+                "X and Y spacing is not the same. "
+                "Cannot write *.asc file in the specified format."
+            )
         cellsize = dx
 
     xllcenter = x[0]
@@ -84,35 +94,35 @@ def write_asc_grid(x, y, z, filename='output.asc', style=1):
     xllcorner = -1
     yllcorner = -1
     if style == 2:
-        xllcorner = xllcenter - dx/2.0
-        yllcorner = yllcenter - dy/2.0
+        xllcorner = xllcenter - dx / 2.0
+        yllcorner = yllcenter - dy / 2.0
 
-    no_data = -999.
+    no_data = -999.0
 
-    with io.open(filename, 'w') as f:
+    with io.open(filename, "w") as f:
         if style == 1:
-            f.write("NCOLS          " + '{:<10n}'.format(ncols) + '\n')
-            f.write("NROWS          " + '{:<10n}'.format(nrows) + '\n')
-            f.write("XLLCENTER      " + '{:<10.2f}'.format(xllcenter) + '\n')
-            f.write("YLLCENTER      " + '{:<10.2f}'.format(yllcenter) + '\n')
-            f.write("DX             " + '{:<10.2f}'.format(dx) + '\n')
-            f.write("DY             " + '{:<10.2f}'.format(dy) + '\n')
-            f.write("NODATA_VALUE   " + '{:<10.2f}'.format(no_data) + '\n')
+            f.write("NCOLS          " + "{:<10n}".format(ncols) + "\n")
+            f.write("NROWS          " + "{:<10n}".format(nrows) + "\n")
+            f.write("XLLCENTER      " + "{:<10.2f}".format(xllcenter) + "\n")
+            f.write("YLLCENTER      " + "{:<10.2f}".format(yllcenter) + "\n")
+            f.write("DX             " + "{:<10.2f}".format(dx) + "\n")
+            f.write("DY             " + "{:<10.2f}".format(dy) + "\n")
+            f.write("NODATA_VALUE   " + "{:<10.2f}".format(no_data) + "\n")
         elif style == 2:
-            f.write("NCOLS          " + '{:<10n}'.format(ncols) + '\n')
-            f.write("NROWS          " + '{:<10n}'.format(nrows) + '\n')
-            f.write("XLLCORNER      " + '{:<10.2f}'.format(xllcorner) + '\n')
-            f.write("YLLCORNER      " + '{:<10.2f}'.format(yllcorner) + '\n')
-            f.write("CELLSIZE       " + '{:<10.2f}'.format(cellsize) + '\n')
-            f.write("NODATA_VALUE   " + '{:<10.2f}'.format(no_data) + '\n')
+            f.write("NCOLS          " + "{:<10n}".format(ncols) + "\n")
+            f.write("NROWS          " + "{:<10n}".format(nrows) + "\n")
+            f.write("XLLCORNER      " + "{:<10.2f}".format(xllcorner) + "\n")
+            f.write("YLLCORNER      " + "{:<10.2f}".format(yllcorner) + "\n")
+            f.write("CELLSIZE       " + "{:<10.2f}".format(cellsize) + "\n")
+            f.write("NODATA_VALUE   " + "{:<10.2f}".format(no_data) + "\n")
         else:
             raise ValueError("style kwarg must be either 1 or 2.")
 
         for m in range(z.shape[0] - 1, -1, -1):
             for n in range(z.shape[1]):
-                f.write('{:<16.2f}'.format(z[m, n]))
+                f.write("{:<16.2f}".format(z[m, n]))
             if m != 0:
-                f.write('\n')
+                f.write("\n")
 
 
 def read_asc_grid(filename, footer=0):
@@ -154,68 +164,75 @@ def read_asc_grid(filename, footer=0):
     dy = None
     no_data = None
     header_lines = 0
-    with io.open(filename, 'r') as f:
+    with io.open(filename, "r") as f:
         while True:
             string, value = f.readline().split()
             header_lines += 1
-            if string.lower() == 'ncols':
+            if string.lower() == "ncols":
                 ncols = int(value)
-            elif string.lower() == 'nrows':
+            elif string.lower() == "nrows":
                 nrows = int(value)
-            elif string.lower() == 'xllcorner':
+            elif string.lower() == "xllcorner":
                 xllcorner = float(value)
-            elif string.lower() == 'xllcenter':
+            elif string.lower() == "xllcenter":
                 xllcenter = float(value)
-            elif string.lower() == 'yllcorner':
+            elif string.lower() == "yllcorner":
                 yllcorner = float(value)
-            elif string.lower() == 'yllcenter':
+            elif string.lower() == "yllcenter":
                 yllcenter = float(value)
-            elif string.lower() == 'cellsize':
+            elif string.lower() == "cellsize":
                 cellsize = float(value)
-            elif string.lower() == 'cell_size':
+            elif string.lower() == "cell_size":
                 cellsize = float(value)
-            elif string.lower() == 'dx':
+            elif string.lower() == "dx":
                 dx = float(value)
-            elif string.lower() == 'dy':
+            elif string.lower() == "dy":
                 dy = float(value)
-            elif string.lower() == 'nodata_value':
+            elif string.lower() == "nodata_value":
                 no_data = float(value)
-            elif string.lower() == 'nodatavalue':
+            elif string.lower() == "nodatavalue":
                 no_data = float(value)
             else:
                 raise IOError("could not read *.asc file. Error in header.")
 
-            if (ncols is not None) and \
-               (nrows is not None) and \
-               (((xllcorner is not None) and (yllcorner is not None)) or
-                ((xllcenter is not None) and (yllcenter is not None))) and \
-               ((cellsize is not None) or ((dx is not None) and (dy is not None))) and \
-               (no_data is not None):
+            if (
+                (ncols is not None)
+                and (nrows is not None)
+                and (
+                    ((xllcorner is not None) and (yllcorner is not None))
+                    or ((xllcenter is not None) and (yllcenter is not None))
+                )
+                and ((cellsize is not None) or ((dx is not None) and (dy is not None)))
+                and (no_data is not None)
+            ):
                 break
 
-    raw_grid_array = np.genfromtxt(filename, skip_header=header_lines,
-                                   skip_footer=footer)
+    raw_grid_array = np.genfromtxt(
+        filename, skip_header=header_lines, skip_footer=footer
+    )
     grid_array = np.flipud(raw_grid_array)
 
     if nrows != grid_array.shape[0] or ncols != grid_array.shape[1]:
-        raise IOError("Error reading *.asc file. Encountered problem "
-                      "with header: NCOLS and/or NROWS does not match "
-                      "number of columns/rows in data file body.")
+        raise IOError(
+            "Error reading *.asc file. Encountered problem "
+            "with header: NCOLS and/or NROWS does not match "
+            "number of columns/rows in data file body."
+        )
 
     if xllcorner is not None and yllcorner is not None:
         if dx is not None and dy is not None:
-            xllcenter = xllcorner + dx/2.0
-            yllcenter = yllcorner + dy/2.0
+            xllcenter = xllcorner + dx / 2.0
+            yllcenter = yllcorner + dy / 2.0
         else:
-            xllcenter = xllcorner + cellsize/2.0
-            yllcenter = yllcorner + cellsize/2.0
+            xllcenter = xllcorner + cellsize / 2.0
+            yllcenter = yllcorner + cellsize / 2.0
 
     if dx is not None and dy is not None:
-        x = np.arange(xllcenter, xllcenter + ncols*dx, dx)
-        y = np.arange(yllcenter, yllcenter + nrows*dy, dy)
+        x = np.arange(xllcenter, xllcenter + ncols * dx, dx)
+        y = np.arange(yllcenter, yllcenter + nrows * dy, dy)
     else:
-        x = np.arange(xllcenter, xllcenter + ncols*cellsize, cellsize)
-        y = np.arange(yllcenter, yllcenter + nrows*cellsize, cellsize)
+        x = np.arange(xllcenter, xllcenter + ncols * cellsize, cellsize)
+        y = np.arange(yllcenter, yllcenter + nrows * cellsize, cellsize)
 
     # Sometimes x and y and can be an entry too long due to imprecision
     # in calculating the upper cutoff for np.arange(); this bit takes care of

--- a/pykrige/lib/__init__.py
+++ b/pykrige/lib/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['cok', 'lapack', 'variogram_models']
+__all__ = ["cok", "lapack", "variogram_models"]

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -194,12 +194,12 @@ class OrdinaryKriging:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -394,12 +394,12 @@ class OrdinaryKriging:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -784,7 +784,7 @@ class OrdinaryKriging:
             print("Executing Ordinary Kriging...\n")
 
         if style != "grid" and style != "masked" and style != "points":
-            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         if n_closest_points is not None and n_closest_points <= 1:
             # If this is not checked, nondescriptive errors emerge
@@ -802,14 +802,14 @@ class OrdinaryKriging:
             if style == "masked":
                 if mask is None:
                     raise IOError(
-                        "Must specify boolean masking array " "when style is 'masked'."
+                        "Must specify boolean masking array when style is 'masked'."
                     )
                 if mask.shape[0] != ny or mask.shape[1] != nx:
                     if mask.shape[0] == nx and mask.shape[1] == ny:
                         mask = mask.T
                     else:
                         raise ValueError(
-                            "Mask dimensions do not match " "specified grid dimensions."
+                            "Mask dimensions do not match specified grid dimensions."
                         )
                 mask = mask.flatten()
             npt = ny * nx
@@ -826,7 +826,7 @@ class OrdinaryKriging:
                 )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         if self.coordinates_type == "euclidean":
             xpts, ypts = _adjust_for_anisotropy(
@@ -864,7 +864,7 @@ class OrdinaryKriging:
                 backend = "loop"
             except:
                 raise RuntimeError(
-                    "Unknown error in trying to " "load Cython extension."
+                    "Unknown error in trying to load Cython extension."
                 )
 
             c_pars = {

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -439,7 +439,11 @@ class OrdinaryKriging:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
             self.Z,
             self.variogram_model,
@@ -863,9 +867,7 @@ class OrdinaryKriging:
                 )
                 backend = "loop"
             except:
-                raise RuntimeError(
-                    "Unknown error in trying to load Cython extension."
-                )
+                raise RuntimeError("Unknown error in trying to load Cython extension.")
 
             c_pars = {
                 key: getattr(self, key)

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -16,7 +16,7 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 
 import numpy as np
@@ -24,8 +24,12 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 from . import variogram_models
 from . import core
-from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list, _find_statistics
+from .core import (
+    _adjust_for_anisotropy,
+    _initialize_variogram_model,
+    _make_variogram_parameter_list,
+    _find_statistics,
+)
 import warnings
 
 
@@ -143,19 +147,33 @@ class OrdinaryKriging:
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
     """
 
-    eps = 1.e-10   # Cutoff for comparison to zero
-    variogram_dict = {'linear': variogram_models.linear_variogram_model,
-                      'power': variogram_models.power_variogram_model,
-                      'gaussian': variogram_models.gaussian_variogram_model,
-                      'spherical': variogram_models.spherical_variogram_model,
-                      'exponential': variogram_models.exponential_variogram_model,
-                      'hole-effect': variogram_models.hole_effect_variogram_model}
+    eps = 1.0e-10  # Cutoff for comparison to zero
+    variogram_dict = {
+        "linear": variogram_models.linear_variogram_model,
+        "power": variogram_models.power_variogram_model,
+        "gaussian": variogram_models.gaussian_variogram_model,
+        "spherical": variogram_models.spherical_variogram_model,
+        "exponential": variogram_models.exponential_variogram_model,
+        "hole-effect": variogram_models.hole_effect_variogram_model,
+    }
 
-    def __init__(self, x, y, z, variogram_model='linear',
-                 variogram_parameters=None, variogram_function=None, nlags=6,
-                 weight=False, anisotropy_scaling=1.0, anisotropy_angle=0.0,
-                 verbose=False, enable_plotting=False, enable_statistics=False,
-                 coordinates_type='euclidean'):
+    def __init__(
+        self,
+        x,
+        y,
+        z,
+        variogram_model="linear",
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling=1.0,
+        anisotropy_angle=0.0,
+        verbose=False,
+        enable_plotting=False,
+        enable_statistics=False,
+        coordinates_type="euclidean",
+    ):
 
         # set up variogram model and parameters...
         self.variogram_model = variogram_model
@@ -171,14 +189,18 @@ class OrdinaryKriging:
             variogram_parameters = []
             anisotropy_scaling = self.model.pykrige_anis
             anisotropy_angle = self.model.pykrige_angle
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
@@ -189,12 +211,13 @@ class OrdinaryKriging:
         # problems with referencing the original passed arguments.
         # Also, values are forced to be float... in the future, might be worth
         # developing complex-number kriging (useful for vector field kriging)
-        self.X_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(x, copy=True, dtype=np.float64)))
-        self.Y_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(y, copy=True, dtype=np.float64)))
-        self.Z = \
-            np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
+        self.X_ORIG = np.atleast_1d(
+            np.squeeze(np.array(x, copy=True, dtype=np.float64))
+        )
+        self.Y_ORIG = np.atleast_1d(
+            np.squeeze(np.array(y, copy=True, dtype=np.float64))
+        )
+        self.Z = np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
 
         self.verbose = verbose
         self.enable_plotting = enable_plotting
@@ -203,93 +226,118 @@ class OrdinaryKriging:
 
         # adjust for anisotropy... only implemented for euclidean (rectangular)
         # coordinates, as anisotropy is ambiguous for geographic coordinates...
-        if coordinates_type == 'euclidean':
-            self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG))/2.0
-            self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG))/2.0
+        if coordinates_type == "euclidean":
+            self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG)) / 2.0
+            self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG)) / 2.0
             self.anisotropy_scaling = anisotropy_scaling
             self.anisotropy_angle = anisotropy_angle
             if self.verbose:
                 print("Adjusting data for anisotropy...")
-            self.X_ADJUSTED, self.Y_ADJUSTED = \
-                _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG)).T,
-                                       [self.XCENTER, self.YCENTER],
-                                       [self.anisotropy_scaling],
-                                       [self.anisotropy_angle]).T
-        elif coordinates_type == 'geographic':
+            self.X_ADJUSTED, self.Y_ADJUSTED = _adjust_for_anisotropy(
+                np.vstack((self.X_ORIG, self.Y_ORIG)).T,
+                [self.XCENTER, self.YCENTER],
+                [self.anisotropy_scaling],
+                [self.anisotropy_angle],
+            ).T
+        elif coordinates_type == "geographic":
             # Leave everything as is in geographic case.
             # May be open to discussion?
             if anisotropy_scaling != 1.0:
-                warnings.warn("Anisotropy is not compatible with geographic "
-                              "coordinates. Ignoring user set anisotropy.",
-                              UserWarning)
-            self.XCENTER= 0.0
-            self.YCENTER= 0.0
+                warnings.warn(
+                    "Anisotropy is not compatible with geographic "
+                    "coordinates. Ignoring user set anisotropy.",
+                    UserWarning,
+                )
+            self.XCENTER = 0.0
+            self.YCENTER = 0.0
             self.anisotropy_scaling = 1.0
             self.anisotropy_angle = 0.0
             self.X_ADJUSTED = self.X_ORIG
             self.Y_ADJUSTED = self.Y_ORIG
         else:
-            raise ValueError("Only 'euclidean' and 'geographic' are valid "
-                             "values for coordinates-keyword.")
+            raise ValueError(
+                "Only 'euclidean' and 'geographic' are valid "
+                "values for coordinates-keyword."
+            )
         self.coordinates_type = coordinates_type
 
         if self.verbose:
             print("Initializing variogram model...")
 
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED)).T,
-                                        self.Z, self.variogram_model, vp_temp,
-                                        self.variogram_function, nlags,
-                                        weight, self.coordinates_type)
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            self.coordinates_type,
+        )
 
         if self.verbose:
-            print("Coordinates type: '%s'" % self.coordinates_type, '\n')
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            print("Coordinates type: '%s'" % self.coordinates_type, "\n")
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
         if enable_statistics:
-            self.delta, self.sigma, self.epsilon = \
-                _find_statistics(np.vstack((self.X_ADJUSTED,
-                                            self.Y_ADJUSTED)).T,
-                                 self.Z, self.variogram_function,
-                                 self.variogram_model_parameters,
-                                 self.coordinates_type)
+            self.delta, self.sigma, self.epsilon = _find_statistics(
+                np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+                self.Z,
+                self.variogram_function,
+                self.variogram_model_parameters,
+                self.coordinates_type,
+            )
             self.Q1 = core.calcQ1(self.epsilon)
             self.Q2 = core.calcQ2(self.epsilon)
             self.cR = core.calc_cR(self.Q2, self.sigma)
             if self.verbose:
                 print("Q1 =", self.Q1)
                 print("Q2 =", self.Q2)
-                print("cR =", self.cR, '\n')
+                print("cR =", self.cR, "\n")
         else:
-            self.delta, self.sigma, self.epsilon, self.Q1, self.Q2, self.cR = [None]*6
+            self.delta, self.sigma, self.epsilon, self.Q1, self.Q2, self.cR = [None] * 6
 
-    def update_variogram_model(self, variogram_model, variogram_parameters=None,
-                               variogram_function=None, nlags=6, weight=False,
-                               anisotropy_scaling=1., anisotropy_angle=0.):
+    def update_variogram_model(
+        self,
+        variogram_model,
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling=1.0,
+        anisotropy_angle=0.0,
+    ):
         """Allows user to update variogram type and/or
         variogram model parameters.
 
@@ -341,36 +389,45 @@ class OrdinaryKriging:
             variogram_parameters = []
             anisotropy_scaling = self.model.pykrige_anis
             anisotropy_angle = self.model.pykrige_angle
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
             self.variogram_function = self.variogram_dict[self.variogram_model]
 
-        if anisotropy_scaling != self.anisotropy_scaling or \
-           anisotropy_angle != self.anisotropy_angle:
-            if self.coordinates_type == 'euclidean':
+        if (
+            anisotropy_scaling != self.anisotropy_scaling
+            or anisotropy_angle != self.anisotropy_angle
+        ):
+            if self.coordinates_type == "euclidean":
                 if self.verbose:
                     print("Adjusting data for anisotropy...")
                 self.anisotropy_scaling = anisotropy_scaling
                 self.anisotropy_angle = anisotropy_angle
-                self.X_ADJUSTED, self.Y_ADJUSTED = \
-                    _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG)).T,
-                                           [self.XCENTER, self.YCENTER],
-                                           [self.anisotropy_scaling],
-                                           [self.anisotropy_angle]).T
-            elif self.coordinates_type == 'geographic':
+                self.X_ADJUSTED, self.Y_ADJUSTED = _adjust_for_anisotropy(
+                    np.vstack((self.X_ORIG, self.Y_ORIG)).T,
+                    [self.XCENTER, self.YCENTER],
+                    [self.anisotropy_scaling],
+                    [self.anisotropy_angle],
+                ).T
+            elif self.coordinates_type == "geographic":
                 if anisotropy_scaling != 1.0:
-                    warnings.warn("Anisotropy is not compatible with geographic"
-                                  " coordinates. Ignoring user set anisotropy.",
-                                  UserWarning)
+                    warnings.warn(
+                        "Anisotropy is not compatible with geographic"
+                        " coordinates. Ignoring user set anisotropy.",
+                        UserWarning,
+                    )
                 self.anisotropy_scaling = 1.0
                 self.anisotropy_angle = 0.0
                 self.X_ADJUSTED = self.X_ORIG
@@ -379,52 +436,62 @@ class OrdinaryKriging:
             print("Updating variogram mode...")
 
         # See note above about the 'use_psill' kwarg...
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED)).T,
-                                        self.Z, self.variogram_model, vp_temp,
-                                        self.variogram_function, nlags,
-                                        weight, self.coordinates_type)
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            self.coordinates_type,
+        )
 
         if self.verbose:
-            print("Coordinates type: '%s'" % self.coordinates_type, '\n')
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            print("Coordinates type: '%s'" % self.coordinates_type, "\n")
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
-                             self.Z, self.variogram_function,
-                             self.variogram_model_parameters,
-                             self.coordinates_type)
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            self.coordinates_type,
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
     def display_variogram_model(self):
         """Displays variogram model with the actual binned data."""
@@ -432,10 +499,12 @@ class OrdinaryKriging:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(self.lags, self.semivariance, 'r*')
-        ax.plot(self.lags,
-                self.variogram_function(self.variogram_model_parameters,
-                                        self.lags), 'k-')
+        ax.plot(self.lags, self.semivariance, "r*")
+        ax.plot(
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+            "k-",
+        )
         plt.show()
 
     def get_variogram_points(self):
@@ -453,7 +522,10 @@ class OrdinaryKriging:
             lags (array) - the lags at which the variogram was evaluated
             variogram (array) - the variogram function evaluated at the lags
         """
-        return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
+        return (
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+        )
 
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""
@@ -473,7 +545,7 @@ class OrdinaryKriging:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.scatter(range(self.epsilon.size), self.epsilon, c='k', marker='*')
+        ax.scatter(range(self.epsilon.size), self.epsilon, c="k", marker="*")
         ax.axhline(y=0.0)
         plt.show()
 
@@ -495,18 +567,21 @@ class OrdinaryKriging:
     def _get_kriging_matrix(self, n):
         """Assembles the kriging matrix."""
 
-        if self.coordinates_type == 'euclidean':
-            xy = np.concatenate((self.X_ADJUSTED[:, np.newaxis],
-                                 self.Y_ADJUSTED[:, np.newaxis]), axis=1)
-            d = cdist(xy, xy, 'euclidean')
-        elif self.coordinates_type == 'geographic':
-            d = core.great_circle_distance(self.X_ADJUSTED[:,np.newaxis],
-                                           self.Y_ADJUSTED[:,np.newaxis],
-                                           self.X_ADJUSTED, self.Y_ADJUSTED)
-        a = np.zeros((n+1, n+1))
-        a[:n, :n] = - self.variogram_function(self.variogram_model_parameters,
-                                              d)
-        np.fill_diagonal(a, 0.)
+        if self.coordinates_type == "euclidean":
+            xy = np.concatenate(
+                (self.X_ADJUSTED[:, np.newaxis], self.Y_ADJUSTED[:, np.newaxis]), axis=1
+            )
+            d = cdist(xy, xy, "euclidean")
+        elif self.coordinates_type == "geographic":
+            d = core.great_circle_distance(
+                self.X_ADJUSTED[:, np.newaxis],
+                self.Y_ADJUSTED[:, np.newaxis],
+                self.X_ADJUSTED,
+                self.Y_ADJUSTED,
+            )
+        a = np.zeros((n + 1, n + 1))
+        a[:n, :n] = -self.variogram_function(self.variogram_model_parameters, d)
+        np.fill_diagonal(a, 0.0)
         a[n, :] = 1.0
         a[:, n] = 1.0
         a[n, n] = 0.0
@@ -528,17 +603,17 @@ class OrdinaryKriging:
             zero_value = True
             zero_index = np.where(np.absolute(bd) <= self.eps)
 
-        b = np.zeros((npt, n+1, 1))
-        b[:, :n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+        b = np.zeros((npt, n + 1, 1))
+        b[:, :n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
         if zero_value:
             b[zero_index[0], zero_index[1], 0] = 0.0
         b[:, n, 0] = 1.0
 
         if (~mask).any():
-            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis], n+1, axis=1)
+            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis], n + 1, axis=1)
             b = np.ma.array(b, mask=mask_b)
 
-        x = np.dot(a_inv, b.reshape((npt, n+1)).T).reshape((1, n+1, npt)).T
+        x = np.dot(a_inv, b.reshape((npt, n + 1)).T).reshape((1, n + 1, npt)).T
         zvalues = np.sum(x[:, :n, 0] * self.Z, axis=1)
         sigmasq = np.sum(x[:, :, 0] * -b[:, :, 0], axis=1)
 
@@ -555,8 +630,10 @@ class OrdinaryKriging:
 
         a_inv = scipy.linalg.inv(a)
 
-        for j in np.nonzero(~mask)[0]:   # Note that this is the same thing as range(npt) if mask is not defined,
-            bd = bd_all[j]               # otherwise it takes the non-masked elements.
+        for j in np.nonzero(~mask)[
+            0
+        ]:  # Note that this is the same thing as range(npt) if mask is not defined,
+            bd = bd_all[j]  # otherwise it takes the non-masked elements.
             if np.any(np.absolute(bd) <= self.eps):
                 zero_value = True
                 zero_index = np.where(np.absolute(bd) <= self.eps)
@@ -564,8 +641,8 @@ class OrdinaryKriging:
                 zero_index = None
                 zero_value = False
 
-            b = np.zeros((n+1, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b = np.zeros((n + 1, 1))
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
             b[n, 0] = 1.0
@@ -585,8 +662,10 @@ class OrdinaryKriging:
         zvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        for i in np.nonzero(~mask)[0]:   # Note that this is the same thing as range(npt) if mask is not defined,
-            b_selector = bd_idx[i]       # otherwise it takes the non-masked elements.
+        for i in np.nonzero(~mask)[
+            0
+        ]:  # Note that this is the same thing as range(npt) if mask is not defined,
+            b_selector = bd_idx[i]  # otherwise it takes the non-masked elements.
             bd = bd_all[i]
 
             a_selector = np.concatenate((b_selector, np.array([a_all.shape[0] - 1])))
@@ -598,8 +677,8 @@ class OrdinaryKriging:
             else:
                 zero_index = None
                 zero_value = False
-            b = np.zeros((n+1, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b = np.zeros((n + 1, 1))
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
             b[n, 0] = 1.0
@@ -607,12 +686,19 @@ class OrdinaryKriging:
             x = scipy.linalg.solve(a, b)
 
             zvalues[i] = x[:n, 0].dot(self.Z[b_selector])
-            sigmasq[i] = - x[:, 0].dot(b[:, 0])
+            sigmasq[i] = -x[:, 0].dot(b[:, 0])
 
         return zvalues, sigmasq
 
-    def execute(self, style, xpoints, ypoints, mask=None, backend='vectorized',
-                n_closest_points=None):
+    def execute(
+        self,
+        style,
+        xpoints,
+        ypoints,
+        mask=None,
+        backend="vectorized",
+        n_closest_points=None,
+    ):
         """Calculates a kriged grid and the associated variance.
 
         This is now the method that performs the main kriging calculation.
@@ -697,9 +783,8 @@ class OrdinaryKriging:
         if self.verbose:
             print("Executing Ordinary Kriging...\n")
 
-        if style != 'grid' and style != 'masked' and style != 'points':
-            raise ValueError("style argument must be 'grid', "
-                             "'points', or 'masked'")
+        if style != "grid" and style != "masked" and style != "points":
+            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
 
         if n_closest_points is not None and n_closest_points <= 1:
             # If this is not checked, nondescriptive errors emerge
@@ -713,69 +798,87 @@ class OrdinaryKriging:
         ny = ypts.size
         a = self._get_kriging_matrix(n)
 
-        if style in ['grid', 'masked']:
-            if style == 'masked':
+        if style in ["grid", "masked"]:
+            if style == "masked":
                 if mask is None:
-                    raise IOError("Must specify boolean masking array "
-                                  "when style is 'masked'.")
+                    raise IOError(
+                        "Must specify boolean masking array " "when style is 'masked'."
+                    )
                 if mask.shape[0] != ny or mask.shape[1] != nx:
                     if mask.shape[0] == nx and mask.shape[1] == ny:
                         mask = mask.T
                     else:
-                        raise ValueError("Mask dimensions do not match "
-                                         "specified grid dimensions.")
+                        raise ValueError(
+                            "Mask dimensions do not match " "specified grid dimensions."
+                        )
                 mask = mask.flatten()
-            npt = ny*nx
+            npt = ny * nx
             grid_x, grid_y = np.meshgrid(xpts, ypts)
             xpts = grid_x.flatten()
             ypts = grid_y.flatten()
 
-        elif style == 'points':
+        elif style == "points":
             if xpts.size != ypts.size:
-                raise ValueError("xpoints and ypoints must have "
-                                 "same dimensions when treated as "
-                                 "listing discrete points.")
+                raise ValueError(
+                    "xpoints and ypoints must have "
+                    "same dimensions when treated as "
+                    "listing discrete points."
+                )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', "
-                             "'points', or 'masked'")
+            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
 
-        if self.coordinates_type == 'euclidean':
-            xpts, ypts = _adjust_for_anisotropy(np.vstack((xpts, ypts)).T,
-                                                [self.XCENTER, self.YCENTER],
-                                                [self.anisotropy_scaling],
-                                                [self.anisotropy_angle]).T
+        if self.coordinates_type == "euclidean":
+            xpts, ypts = _adjust_for_anisotropy(
+                np.vstack((xpts, ypts)).T,
+                [self.XCENTER, self.YCENTER],
+                [self.anisotropy_scaling],
+                [self.anisotropy_angle],
+            ).T
             # Prepare for cdist:
-            xy_data = np.concatenate((self.X_ADJUSTED[:, np.newaxis],
-                                      self.Y_ADJUSTED[:, np.newaxis]), axis=1)
-            xy_points = np.concatenate((xpts[:, np.newaxis],
-                                        ypts[:, np.newaxis]), axis=1)
-        elif self.coordinates_type == 'geographic':
+            xy_data = np.concatenate(
+                (self.X_ADJUSTED[:, np.newaxis], self.Y_ADJUSTED[:, np.newaxis]), axis=1
+            )
+            xy_points = np.concatenate(
+                (xpts[:, np.newaxis], ypts[:, np.newaxis]), axis=1
+            )
+        elif self.coordinates_type == "geographic":
             # In spherical coordinates, we do not correct for anisotropy.
             # Also, we don't use scipy.spatial.cdist, so we do not have to
             # format the input data accordingly.
             pass
 
-        if style != 'masked':
-            mask = np.zeros(npt, dtype='bool')
+        if style != "masked":
+            mask = np.zeros(npt, dtype="bool")
 
         c_pars = None
-        if backend == 'C':
+        if backend == "C":
             try:
                 from .lib.cok import _c_exec_loop, _c_exec_loop_moving_window
             except ImportError:
-                print('Warning: failed to load Cython extensions.\n'
-                      '   See https://github.com/GeoStat-Framework/PyKrige/issues/8 \n'
-                      '   Falling back to a pure python backend...')
-                backend = 'loop'
+                print(
+                    "Warning: failed to load Cython extensions.\n"
+                    "   See https://github.com/GeoStat-Framework/PyKrige/issues/8 \n"
+                    "   Falling back to a pure python backend..."
+                )
+                backend = "loop"
             except:
-                raise RuntimeError("Unknown error in trying to "
-                                   "load Cython extension.")
+                raise RuntimeError(
+                    "Unknown error in trying to " "load Cython extension."
+                )
 
-            c_pars = {key: getattr(self, key) for key in ['Z', 'eps', 'variogram_model_parameters', 'variogram_function']}
+            c_pars = {
+                key: getattr(self, key)
+                for key in [
+                    "Z",
+                    "eps",
+                    "variogram_model_parameters",
+                    "variogram_function",
+                ]
+            }
 
         if n_closest_points is not None:
-            if self.coordinates_type == 'geographic':
+            if self.coordinates_type == "geographic":
                 # To make use of the KDTree, we have to convert the
                 # spherical coordinates into three dimensional Euclidean
                 # coordinates, since the standard KDTree cannot handle
@@ -783,64 +886,80 @@ class OrdinaryKriging:
                 # Do the conversion just for the step involving the KDTree:
                 lon_d = self.X_ADJUSTED[:, np.newaxis] * np.pi / 180.0
                 lat_d = self.Y_ADJUSTED[:, np.newaxis] * np.pi / 180.0
-                xy_data = np.concatenate((np.cos(lon_d) * np.cos(lat_d),
-                                          np.sin(lon_d) * np.cos(lat_d),
-                                          np.sin(lat_d)), axis=1)
+                xy_data = np.concatenate(
+                    (
+                        np.cos(lon_d) * np.cos(lat_d),
+                        np.sin(lon_d) * np.cos(lat_d),
+                        np.sin(lat_d),
+                    ),
+                    axis=1,
+                )
                 lon_p = xpts[:, np.newaxis] * np.pi / 180.0
                 lat_p = ypts[:, np.newaxis] * np.pi / 180.0
-                xy_points = np.concatenate((np.cos(lon_p) * np.cos(lat_p),
-                                            np.sin(lon_p) * np.cos(lat_p),
-                                            np.sin(lat_p)), axis=1)
+                xy_points = np.concatenate(
+                    (
+                        np.cos(lon_p) * np.cos(lat_p),
+                        np.sin(lon_p) * np.cos(lat_p),
+                        np.sin(lat_p),
+                    ),
+                    axis=1,
+                )
 
             from scipy.spatial import cKDTree
+
             tree = cKDTree(xy_data)
             bd, bd_idx = tree.query(xy_points, k=n_closest_points, eps=0.0)
 
-            if self.coordinates_type == 'geographic':
+            if self.coordinates_type == "geographic":
                 # Between the nearest neighbours from Euclidean search,
                 # calculate the great circle distance using the standard method:
-                x_points = np.tile(xpts[:,np.newaxis],(1,n_closest_points))
-                y_points = np.tile(ypts[:,np.newaxis],(1,n_closest_points))
-                bd = core.great_circle_distance(x_points, y_points,
-                                                self.X_ADJUSTED[bd_idx],
-                                                self.Y_ADJUSTED[bd_idx])
+                x_points = np.tile(xpts[:, np.newaxis], (1, n_closest_points))
+                y_points = np.tile(ypts[:, np.newaxis], (1, n_closest_points))
+                bd = core.great_circle_distance(
+                    x_points, y_points, self.X_ADJUSTED[bd_idx], self.Y_ADJUSTED[bd_idx]
+                )
 
-            if backend == 'loop':
-                zvalues, sigmasq = \
-                    self._exec_loop_moving_window(a, bd, mask, bd_idx)
-            elif backend == 'C':
-                zvalues, sigmasq = \
-                    _c_exec_loop_moving_window(a, bd, mask.astype('int8'),
-                                               bd_idx, self.X_ADJUSTED.shape[0],
-                                               c_pars)
+            if backend == "loop":
+                zvalues, sigmasq = self._exec_loop_moving_window(a, bd, mask, bd_idx)
+            elif backend == "C":
+                zvalues, sigmasq = _c_exec_loop_moving_window(
+                    a, bd, mask.astype("int8"), bd_idx, self.X_ADJUSTED.shape[0], c_pars
+                )
             else:
-                raise ValueError('Specified backend {} for a moving window '
-                                 'is not supported.'.format(backend))
+                raise ValueError(
+                    "Specified backend {} for a moving window "
+                    "is not supported.".format(backend)
+                )
         else:
-            if self.coordinates_type == 'euclidean':
-                bd = cdist(xy_points,  xy_data, 'euclidean')
-            elif self.coordinates_type == 'geographic':
-                bd = core.great_circle_distance(xpts[:,np.newaxis],
-                                                ypts[:,np.newaxis],
-                                                self.X_ADJUSTED, self.Y_ADJUSTED)
+            if self.coordinates_type == "euclidean":
+                bd = cdist(xy_points, xy_data, "euclidean")
+            elif self.coordinates_type == "geographic":
+                bd = core.great_circle_distance(
+                    xpts[:, np.newaxis],
+                    ypts[:, np.newaxis],
+                    self.X_ADJUSTED,
+                    self.Y_ADJUSTED,
+                )
 
-            if backend == 'vectorized':
+            if backend == "vectorized":
                 zvalues, sigmasq = self._exec_vector(a, bd, mask)
-            elif backend == 'loop':
+            elif backend == "loop":
                 zvalues, sigmasq = self._exec_loop(a, bd, mask)
-            elif backend == 'C':
-                zvalues, sigmasq = _c_exec_loop(a, bd, mask.astype('int8'),
-                                                self.X_ADJUSTED.shape[0],
-                                                c_pars)
+            elif backend == "C":
+                zvalues, sigmasq = _c_exec_loop(
+                    a, bd, mask.astype("int8"), self.X_ADJUSTED.shape[0], c_pars
+                )
             else:
-                raise ValueError('Specified backend {} is not supported for '
-                                 '2D ordinary kriging.'.format(backend))
+                raise ValueError(
+                    "Specified backend {} is not supported for "
+                    "2D ordinary kriging.".format(backend)
+                )
 
-        if style == 'masked':
+        if style == "masked":
             zvalues = np.ma.array(zvalues, mask=mask)
             sigmasq = np.ma.array(sigmasq, mask=mask)
 
-        if style in ['masked', 'grid']:
+        if style in ["masked", "grid"]:
             zvalues = zvalues.reshape((ny, nx))
             sigmasq = sigmasq.reshape((ny, nx))
 

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -266,7 +266,11 @@ class OrdinaryKriging3D:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
             self.VALUES,
             self.variogram_model,
@@ -444,7 +448,11 @@ class OrdinaryKriging3D:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
             self.VALUES,
             self.variogram_model,

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -15,7 +15,7 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 
 import numpy as np
@@ -23,8 +23,12 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 from . import variogram_models
 from . import core
-from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list, _find_statistics
+from .core import (
+    _adjust_for_anisotropy,
+    _initialize_variogram_model,
+    _make_variogram_parameter_list,
+    _find_statistics,
+)
 import warnings
 
 
@@ -154,19 +158,35 @@ class OrdinaryKriging3D:
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
     """
 
-    eps = 1.e-10   # Cutoff for comparison to zero
-    variogram_dict = {'linear': variogram_models.linear_variogram_model,
-                      'power': variogram_models.power_variogram_model,
-                      'gaussian': variogram_models.gaussian_variogram_model,
-                      'spherical': variogram_models.spherical_variogram_model,
-                      'exponential': variogram_models.exponential_variogram_model,
-                      'hole-effect': variogram_models.hole_effect_variogram_model}
+    eps = 1.0e-10  # Cutoff for comparison to zero
+    variogram_dict = {
+        "linear": variogram_models.linear_variogram_model,
+        "power": variogram_models.power_variogram_model,
+        "gaussian": variogram_models.gaussian_variogram_model,
+        "spherical": variogram_models.spherical_variogram_model,
+        "exponential": variogram_models.exponential_variogram_model,
+        "hole-effect": variogram_models.hole_effect_variogram_model,
+    }
 
-    def __init__(self, x, y, z, val, variogram_model='linear',
-                 variogram_parameters=None, variogram_function=None, nlags=6,
-                 weight=False, anisotropy_scaling_y=1., anisotropy_scaling_z=1.,
-                 anisotropy_angle_x=0., anisotropy_angle_y=0.,
-                 anisotropy_angle_z=0., verbose=False, enable_plotting=False):
+    def __init__(
+        self,
+        x,
+        y,
+        z,
+        val,
+        variogram_model="linear",
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling_y=1.0,
+        anisotropy_scaling_z=1.0,
+        anisotropy_angle_x=0.0,
+        anisotropy_angle_y=0.0,
+        anisotropy_angle_z=0.0,
+        verbose=False,
+        enable_plotting=False,
+    ):
 
         # set up variogram model and parameters...
         self.variogram_model = variogram_model
@@ -185,14 +205,18 @@ class OrdinaryKriging3D:
             anisotropy_angle_x = self.model.pykrige_angle_x
             anisotropy_angle_y = self.model.pykrige_angle_y
             anisotropy_angle_z = self.model.pykrige_angle_z
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
@@ -201,23 +225,27 @@ class OrdinaryKriging3D:
         # Code assumes 1D input arrays. Ensures that any extraneous dimensions
         # don't get in the way. Copies are created to avoid any problems with
         # referencing the original passed arguments.
-        self.X_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(x, copy=True, dtype=np.float64)))
-        self.Y_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(y, copy=True, dtype=np.float64)))
-        self.Z_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
-        self.VALUES = \
-            np.atleast_1d(np.squeeze(np.array(val, copy=True, dtype=np.float64)))
+        self.X_ORIG = np.atleast_1d(
+            np.squeeze(np.array(x, copy=True, dtype=np.float64))
+        )
+        self.Y_ORIG = np.atleast_1d(
+            np.squeeze(np.array(y, copy=True, dtype=np.float64))
+        )
+        self.Z_ORIG = np.atleast_1d(
+            np.squeeze(np.array(z, copy=True, dtype=np.float64))
+        )
+        self.VALUES = np.atleast_1d(
+            np.squeeze(np.array(val, copy=True, dtype=np.float64))
+        )
 
         self.verbose = verbose
         self.enable_plotting = enable_plotting
         if self.enable_plotting and self.verbose:
             print("Plotting Enabled\n")
 
-        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG))/2.0
-        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG))/2.0
-        self.ZCENTER = (np.amax(self.Z_ORIG) + np.amin(self.Z_ORIG))/2.0
+        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG)) / 2.0
+        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG)) / 2.0
+        self.ZCENTER = (np.amax(self.Z_ORIG) + np.amin(self.Z_ORIG)) / 2.0
         self.anisotropy_scaling_y = anisotropy_scaling_y
         self.anisotropy_scaling_z = anisotropy_scaling_z
         self.anisotropy_angle_x = anisotropy_angle_x
@@ -225,68 +253,85 @@ class OrdinaryKriging3D:
         self.anisotropy_angle_z = anisotropy_angle_z
         if self.verbose:
             print("Adjusting data for anisotropy...")
-        self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = \
-            _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
-                                   [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                   [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                   [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z]).T
+        self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = _adjust_for_anisotropy(
+            np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
+            [self.XCENTER, self.YCENTER, self.ZCENTER],
+            [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+            [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z],
+        ).T
 
         if self.verbose:
             print("Initializing variogram model...")
 
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED,
-                                                   self.Z_ADJUSTED)).T,
-                                        self.VALUES, self.variogram_model,
-                                        vp_temp, self.variogram_function,
-                                        nlags, weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED,
-                                        self.Y_ADJUSTED,
-                                        self.Z_ADJUSTED)).T,
-                             self.VALUES,  self.variogram_function,
-                             self.variogram_model_parameters, 'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
-    def update_variogram_model(self, variogram_model, variogram_parameters=None,
-                               variogram_function=None, nlags=6, weight=False,
-                               anisotropy_scaling_y=1., anisotropy_scaling_z=1.,
-                               anisotropy_angle_x=0., anisotropy_angle_y=0.,
-                               anisotropy_angle_z=0.):
+    def update_variogram_model(
+        self,
+        variogram_model,
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling_y=1.0,
+        anisotropy_scaling_z=1.0,
+        anisotropy_angle_x=0.0,
+        anisotropy_angle_y=0.0,
+        anisotropy_angle_z=0.0,
+    ):
         """Changes the variogram model and variogram parameters for
         the kriging system.
 
@@ -351,22 +396,30 @@ class OrdinaryKriging3D:
             anisotropy_angle_x = self.model.pykrige_angle_x
             anisotropy_angle_y = self.model.pykrige_angle_y
             anisotropy_angle_z = self.model.pykrige_angle_z
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
             self.variogram_function = self.variogram_dict[self.variogram_model]
 
-        if anisotropy_scaling_y != self.anisotropy_scaling_y or anisotropy_scaling_z != self.anisotropy_scaling_z or \
-           anisotropy_angle_x != self.anisotropy_angle_x or anisotropy_angle_y != self.anisotropy_angle_y or \
-           anisotropy_angle_z != self.anisotropy_angle_z:
+        if (
+            anisotropy_scaling_y != self.anisotropy_scaling_y
+            or anisotropy_scaling_z != self.anisotropy_scaling_z
+            or anisotropy_angle_x != self.anisotropy_angle_x
+            or anisotropy_angle_y != self.anisotropy_angle_y
+            or anisotropy_angle_z != self.anisotropy_angle_z
+        ):
             if self.verbose:
                 print("Adjusting data for anisotropy...")
             self.anisotropy_scaling_y = anisotropy_scaling_y
@@ -374,62 +427,75 @@ class OrdinaryKriging3D:
             self.anisotropy_angle_x = anisotropy_angle_x
             self.anisotropy_angle_y = anisotropy_angle_y
             self.anisotropy_angle_z = anisotropy_angle_z
-            self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = \
-                _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
-                                       [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                       [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                       [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z]).T
+            self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = _adjust_for_anisotropy(
+                np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
+                [self.XCENTER, self.YCENTER, self.ZCENTER],
+                [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+                [
+                    self.anisotropy_angle_x,
+                    self.anisotropy_angle_y,
+                    self.anisotropy_angle_z,
+                ],
+            ).T
 
         if self.verbose:
             print("Updating variogram mode...")
 
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED,
-                                                   self.Z_ADJUSTED)).T,
-                                        self.VALUES, self.variogram_model,
-                                        vp_temp, self.variogram_function,
-                                        nlags, weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED,
-                                        self.Y_ADJUSTED,
-                                        self.Z_ADJUSTED)).T,
-                             self.VALUES, self.variogram_function,
-                             self.variogram_model_parameters, 'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
     def display_variogram_model(self):
         """Displays variogram model with the actual binned data."""
@@ -437,10 +503,12 @@ class OrdinaryKriging3D:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(self.lags, self.semivariance, 'r*')
-        ax.plot(self.lags,
-                self.variogram_function(self.variogram_model_parameters,
-                                        self.lags), 'k-')
+        ax.plot(self.lags, self.semivariance, "r*")
+        ax.plot(
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+            "k-",
+        )
         plt.show()
 
     def switch_verbose(self):
@@ -461,7 +529,7 @@ class OrdinaryKriging3D:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.scatter(range(self.epsilon.size), self.epsilon, c='k', marker='*')
+        ax.scatter(range(self.epsilon.size), self.epsilon, c="k", marker="*")
         ax.axhline(y=0.0)
         plt.show()
 
@@ -483,13 +551,18 @@ class OrdinaryKriging3D:
     def _get_kriging_matrix(self, n):
         """Assembles the kriging matrix."""
 
-        xyz = np.concatenate((self.X_ADJUSTED[:, np.newaxis],
-                              self.Y_ADJUSTED[:, np.newaxis],
-                              self.Z_ADJUSTED[:, np.newaxis]), axis=1)
-        d = cdist(xyz, xyz, 'euclidean')
-        a = np.zeros((n+1, n+1))
-        a[:n, :n] = - self.variogram_function(self.variogram_model_parameters, d)
-        np.fill_diagonal(a, 0.)
+        xyz = np.concatenate(
+            (
+                self.X_ADJUSTED[:, np.newaxis],
+                self.Y_ADJUSTED[:, np.newaxis],
+                self.Z_ADJUSTED[:, np.newaxis],
+            ),
+            axis=1,
+        )
+        d = cdist(xyz, xyz, "euclidean")
+        a = np.zeros((n + 1, n + 1))
+        a[:n, :n] = -self.variogram_function(self.variogram_model_parameters, d)
+        np.fill_diagonal(a, 0.0)
         a[n, :] = 1.0
         a[:, n] = 1.0
         a[n, n] = 0.0
@@ -511,17 +584,17 @@ class OrdinaryKriging3D:
             zero_value = True
             zero_index = np.where(np.absolute(bd) <= self.eps)
 
-        b = np.zeros((npt, n+1, 1))
-        b[:, :n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+        b = np.zeros((npt, n + 1, 1))
+        b[:, :n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
         if zero_value:
             b[zero_index[0], zero_index[1], 0] = 0.0
         b[:, n, 0] = 1.0
 
         if (~mask).any():
-            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis], n+1, axis=1)
+            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis], n + 1, axis=1)
             b = np.ma.array(b, mask=mask_b)
 
-        x = np.dot(a_inv, b.reshape((npt, n+1)).T).reshape((1, n+1, npt)).T
+        x = np.dot(a_inv, b.reshape((npt, n + 1)).T).reshape((1, n + 1, npt)).T
         kvalues = np.sum(x[:, :n, 0] * self.VALUES, axis=1)
         sigmasq = np.sum(x[:, :, 0] * -b[:, :, 0], axis=1)
 
@@ -538,8 +611,10 @@ class OrdinaryKriging3D:
 
         a_inv = scipy.linalg.inv(a)
 
-        for j in np.nonzero(~mask)[0]:   # Note that this is the same thing as range(npt) if mask is not defined,
-            bd = bd_all[j]               # otherwise it takes the non-masked elements.
+        for j in np.nonzero(~mask)[
+            0
+        ]:  # Note that this is the same thing as range(npt) if mask is not defined,
+            bd = bd_all[j]  # otherwise it takes the non-masked elements.
             if np.any(np.absolute(bd) <= self.eps):
                 zero_value = True
                 zero_index = np.where(np.absolute(bd) <= self.eps)
@@ -547,8 +622,8 @@ class OrdinaryKriging3D:
                 zero_value = False
                 zero_index = None
 
-            b = np.zeros((n+1, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b = np.zeros((n + 1, 1))
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
             b[n, 0] = 1.0
@@ -584,8 +659,8 @@ class OrdinaryKriging3D:
             else:
                 zero_value = False
                 zero_index = None
-            b = np.zeros((n+1, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b = np.zeros((n + 1, 1))
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
             b[n, 0] = 1.0
@@ -593,12 +668,20 @@ class OrdinaryKriging3D:
             x = scipy.linalg.solve(a, b)
 
             kvalues[i] = x[:n, 0].dot(self.VALUES[b_selector])
-            sigmasq[i] = - x[:, 0].dot(b[:, 0])
+            sigmasq[i] = -x[:, 0].dot(b[:, 0])
 
         return kvalues, sigmasq
 
-    def execute(self, style, xpoints, ypoints, zpoints, mask=None,
-                backend='vectorized', n_closest_points=None):
+    def execute(
+        self,
+        style,
+        xpoints,
+        ypoints,
+        zpoints,
+        mask=None,
+        backend="vectorized",
+        n_closest_points=None,
+    ):
         """Calculates a kriged grid and the associated variance.
 
         This is now the method that performs the main kriging calculation.
@@ -684,9 +767,8 @@ class OrdinaryKriging3D:
         if self.verbose:
             print("Executing Ordinary Kriging...\n")
 
-        if style != 'grid' and style != 'masked' and style != 'points':
-            raise ValueError("style argument must be 'grid', 'points', "
-                             "or 'masked'")
+        if style != "grid" and style != "masked" and style != "points":
+            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
 
         xpts = np.atleast_1d(np.squeeze(np.array(xpoints, copy=True)))
         ypts = np.atleast_1d(np.squeeze(np.array(ypoints, copy=True)))
@@ -697,75 +779,93 @@ class OrdinaryKriging3D:
         nz = zpts.size
         a = self._get_kriging_matrix(n)
 
-        if style in ['grid', 'masked']:
-            if style == 'masked':
+        if style in ["grid", "masked"]:
+            if style == "masked":
                 if mask is None:
-                    raise IOError("Must specify boolean masking array when "
-                                  "style is 'masked'.")
+                    raise IOError(
+                        "Must specify boolean masking array when " "style is 'masked'."
+                    )
                 if mask.ndim != 3:
                     raise ValueError("Mask is not three-dimensional.")
                 if mask.shape[0] != nz or mask.shape[1] != ny or mask.shape[2] != nx:
-                    if mask.shape[0] == nx and mask.shape[2] == nz and mask.shape[1] == ny:
+                    if (
+                        mask.shape[0] == nx
+                        and mask.shape[2] == nz
+                        and mask.shape[1] == ny
+                    ):
                         mask = mask.swapaxes(0, 2)
                     else:
-                        raise ValueError("Mask dimensions do not match "
-                                         "specified grid dimensions.")
+                        raise ValueError(
+                            "Mask dimensions do not match " "specified grid dimensions."
+                        )
                 mask = mask.flatten()
             npt = nz * ny * nx
-            grid_z, grid_y, grid_x = np.meshgrid(zpts, ypts, xpts, indexing='ij')
+            grid_z, grid_y, grid_x = np.meshgrid(zpts, ypts, xpts, indexing="ij")
             xpts = grid_x.flatten()
             ypts = grid_y.flatten()
             zpts = grid_z.flatten()
-        elif style == 'points':
+        elif style == "points":
             if xpts.size != ypts.size and ypts.size != zpts.size:
-                raise ValueError("xpoints, ypoints, and zpoints must have "
-                                 "same dimensions when treated as listing "
-                                 "discrete points.")
+                raise ValueError(
+                    "xpoints, ypoints, and zpoints must have "
+                    "same dimensions when treated as listing "
+                    "discrete points."
+                )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', "
-                             "'points', or 'masked'")
+            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
 
-        xpts, ypts, zpts = \
-            _adjust_for_anisotropy(np.vstack((xpts, ypts, zpts)).T,
-                                   [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                   [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                   [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z]).T
+        xpts, ypts, zpts = _adjust_for_anisotropy(
+            np.vstack((xpts, ypts, zpts)).T,
+            [self.XCENTER, self.YCENTER, self.ZCENTER],
+            [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+            [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z],
+        ).T
 
-        if style != 'masked':
-            mask = np.zeros(npt, dtype='bool')
+        if style != "masked":
+            mask = np.zeros(npt, dtype="bool")
 
-        xyz_points = np.concatenate((zpts[:, np.newaxis], ypts[:, np.newaxis],
-                                     xpts[:, np.newaxis]), axis=1)
-        xyz_data = np.concatenate((self.Z_ADJUSTED[:, np.newaxis],
-                                   self.Y_ADJUSTED[:, np.newaxis],
-                                   self.X_ADJUSTED[:, np.newaxis]), axis=1)
-        bd = cdist(xyz_points, xyz_data, 'euclidean')
+        xyz_points = np.concatenate(
+            (zpts[:, np.newaxis], ypts[:, np.newaxis], xpts[:, np.newaxis]), axis=1
+        )
+        xyz_data = np.concatenate(
+            (
+                self.Z_ADJUSTED[:, np.newaxis],
+                self.Y_ADJUSTED[:, np.newaxis],
+                self.X_ADJUSTED[:, np.newaxis],
+            ),
+            axis=1,
+        )
+        bd = cdist(xyz_points, xyz_data, "euclidean")
 
         if n_closest_points is not None:
             from scipy.spatial import cKDTree
+
             tree = cKDTree(xyz_data)
             bd, bd_idx = tree.query(xyz_points, k=n_closest_points, eps=0.0)
-            if backend == 'loop':
-                kvalues, sigmasq = \
-                    self._exec_loop_moving_window(a, bd, mask, bd_idx)
+            if backend == "loop":
+                kvalues, sigmasq = self._exec_loop_moving_window(a, bd, mask, bd_idx)
             else:
-                raise ValueError("Specified backend '{}' not supported "
-                                 "for moving window.".format(backend))
+                raise ValueError(
+                    "Specified backend '{}' not supported "
+                    "for moving window.".format(backend)
+                )
         else:
-            if backend == 'vectorized':
+            if backend == "vectorized":
                 kvalues, sigmasq = self._exec_vector(a, bd, mask)
-            elif backend == 'loop':
+            elif backend == "loop":
                 kvalues, sigmasq = self._exec_loop(a, bd, mask)
             else:
-                raise ValueError('Specified backend {} is not supported for '
-                                 '3D ordinary kriging.'.format(backend))
+                raise ValueError(
+                    "Specified backend {} is not supported for "
+                    "3D ordinary kriging.".format(backend)
+                )
 
-        if style == 'masked':
+        if style == "masked":
             kvalues = np.ma.array(kvalues, mask=mask)
             sigmasq = np.ma.array(sigmasq, mask=mask)
 
-        if style in ['masked', 'grid']:
+        if style in ["masked", "grid"]:
             kvalues = kvalues.reshape((nz, ny, nx))
             sigmasq = sigmasq.reshape((nz, ny, nx))
 

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -210,12 +210,12 @@ class OrdinaryKriging3D:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -401,12 +401,12 @@ class OrdinaryKriging3D:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -768,7 +768,7 @@ class OrdinaryKriging3D:
             print("Executing Ordinary Kriging...\n")
 
         if style != "grid" and style != "masked" and style != "points":
-            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         xpts = np.atleast_1d(np.squeeze(np.array(xpoints, copy=True)))
         ypts = np.atleast_1d(np.squeeze(np.array(ypoints, copy=True)))
@@ -783,7 +783,7 @@ class OrdinaryKriging3D:
             if style == "masked":
                 if mask is None:
                     raise IOError(
-                        "Must specify boolean masking array when " "style is 'masked'."
+                        "Must specify boolean masking array when style is 'masked'."
                     )
                 if mask.ndim != 3:
                     raise ValueError("Mask is not three-dimensional.")
@@ -796,7 +796,7 @@ class OrdinaryKriging3D:
                         mask = mask.swapaxes(0, 2)
                     else:
                         raise ValueError(
-                            "Mask dimensions do not match " "specified grid dimensions."
+                            "Mask dimensions do not match specified grid dimensions."
                         )
                 mask = mask.flatten()
             npt = nz * ny * nx
@@ -813,7 +813,7 @@ class OrdinaryKriging3D:
                 )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', " "'points', or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         xpts, ypts, zpts = _adjust_for_anisotropy(
             np.vstack((xpts, ypts, zpts)).T,

--- a/pykrige/rk.py
+++ b/pykrige/rk.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from pykrige.compat import validate_sklearn
+
 validate_sklearn()
 from pykrige.ok import OrdinaryKriging
 from pykrige.uk import UniversalKriging
@@ -9,19 +10,21 @@ from sklearn.base import RegressorMixin, BaseEstimator
 from sklearn.svm import SVR
 from sklearn.metrics import r2_score
 
-krige_methods = {'ordinary': OrdinaryKriging,
-                 'universal': UniversalKriging,
-                 'ordinary3d': OrdinaryKriging3D,
-                 'universal3d': UniversalKriging3D
-                 }
+krige_methods = {
+    "ordinary": OrdinaryKriging,
+    "universal": UniversalKriging,
+    "ordinary3d": OrdinaryKriging3D,
+    "universal3d": UniversalKriging3D,
+}
 
-threed_krige = ('ordinary3d', 'universal3d')
+threed_krige = ("ordinary3d", "universal3d")
 
 
 def validate_method(method):
     if method not in krige_methods.keys():
-        raise ValueError('Kriging method must be '
-                         'one of {}'.format(krige_methods.keys()))
+        raise ValueError(
+            "Kriging method must be " "one of {}".format(krige_methods.keys())
+        )
 
 
 class Krige(RegressorMixin, BaseEstimator):
@@ -32,13 +35,15 @@ class Krige(RegressorMixin, BaseEstimator):
 
     """
 
-    def __init__(self,
-                 method='ordinary',
-                 variogram_model='linear',
-                 nlags=6,
-                 weight=False,
-                 n_closest_points=10,
-                 verbose=False):
+    def __init__(
+        self,
+        method="ordinary",
+        variogram_model="linear",
+        nlags=6,
+        weight=False,
+        n_closest_points=10,
+        verbose=False,
+    ):
 
         validate_method(method)
         self.variogram_model = variogram_model
@@ -82,19 +87,17 @@ class Krige(RegressorMixin, BaseEstimator):
                 **points
             )
 
-    def _dimensionality_check(self, x, ext=''):
-        if self.method in ('ordinary', 'universal'):
+    def _dimensionality_check(self, x, ext=""):
+        if self.method in ("ordinary", "universal"):
             if x.shape[1] != 2:
-                raise ValueError('2d krige can use only 2d points')
+                raise ValueError("2d krige can use only 2d points")
             else:
-                return {'x' + ext: x[:, 0], 'y' + ext: x[:, 1]}
-        if self.method in ('ordinary3d', 'universal3d'):
+                return {"x" + ext: x[:, 0], "y" + ext: x[:, 1]}
+        if self.method in ("ordinary3d", "universal3d"):
             if x.shape[1] != 3:
-                raise ValueError('3d krige can use only 3d points')
+                raise ValueError("3d krige can use only 3d points")
             else:
-                return {'x' + ext: x[:, 0],
-                        'y' + ext: x[:, 1],
-                        'z' + ext: x[:, 2]}
+                return {"x" + ext: x[:, 0], "y" + ext: x[:, 1], "z" + ext: x[:, 2]}
 
     def predict(self, x, *args, **kwargs):
         """
@@ -109,9 +112,9 @@ class Krige(RegressorMixin, BaseEstimator):
         Prediction array
         """
         if not self.model:
-            raise Exception('Not trained. Train first')
+            raise Exception("Not trained. Train first")
 
-        points = self._dimensionality_check(x, ext='points')
+        points = self._dimensionality_check(x, ext="points")
 
         return self.execute(points, *args, **kwargs)[0]
 
@@ -127,26 +130,29 @@ class Krige(RegressorMixin, BaseEstimator):
         Prediction array
         Variance array
         """
-        if isinstance(self.model, OrdinaryKriging) or \
-                isinstance(self.model, OrdinaryKriging3D):
-            prediction, variance = \
-                self.model.execute('points',
-                                   n_closest_points=self.n_closest_points,
-                                   backend='loop',
-                                   **points)
+        if isinstance(self.model, OrdinaryKriging) or isinstance(
+            self.model, OrdinaryKriging3D
+        ):
+            prediction, variance = self.model.execute(
+                "points",
+                n_closest_points=self.n_closest_points,
+                backend="loop",
+                **points
+            )
         else:
-            print('n_closest_points will be ignored for UniversalKriging')
-            prediction, variance = \
-                self.model.execute('points', backend='loop', **points)
+            print("n_closest_points will be ignored for UniversalKriging")
+            prediction, variance = self.model.execute(
+                "points", backend="loop", **points
+            )
 
         return prediction, variance
 
 
 def check_sklearn_model(model):
-    if not (isinstance(model, BaseEstimator) and
-            isinstance(model, RegressorMixin)):
-        raise RuntimeError('Needs to supply an instance of a scikit-learn '
-                           'regression class.')
+    if not (isinstance(model, BaseEstimator) and isinstance(model, RegressorMixin)):
+        raise RuntimeError(
+            "Needs to supply an instance of a scikit-learn " "regression class."
+        )
 
 
 class RegressionKriging:
@@ -155,14 +161,16 @@ class RegressionKriging:
     https://en.wikipedia.org/wiki/Regression-Kriging
     """
 
-    def __init__(self,
-                 regression_model=SVR(),
-                 method='ordinary',
-                 variogram_model='linear',
-                 n_closest_points=10,
-                 nlags=6,
-                 weight=False,
-                 verbose=False):
+    def __init__(
+        self,
+        regression_model=SVR(),
+        method="ordinary",
+        variogram_model="linear",
+        n_closest_points=10,
+        nlags=6,
+        weight=False,
+        verbose=False,
+    ):
         """
         Parameters
         ----------
@@ -190,7 +198,7 @@ class RegressionKriging:
             weight=weight,
             n_closest_points=n_closest_points,
             verbose=verbose,
-            )
+        )
 
     def fit(self, p, x, y):
         """
@@ -210,10 +218,10 @@ class RegressionKriging:
         """
         self.regression_model.fit(p, y)
         ml_pred = self.regression_model.predict(p)
-        print('Finished learning regression model')
+        print("Finished learning regression model")
         # residual=y-ml_pred
         self.krige.fit(x=x, y=y - ml_pred)
-        print('Finished kriging residuals')
+        print("Finished kriging residuals")
 
     def predict(self, p, x):
         """
@@ -268,8 +276,6 @@ class RegressionKriging:
             array of targets (Ns, )
         """
 
-        return r2_score(y_pred=self.predict(p, x),
-                        y_true=y,
-                        sample_weight=sample_weight)
-
-
+        return r2_score(
+            y_pred=self.predict(p, x), y_true=y, sample_weight=sample_weight
+        )

--- a/pykrige/rk.py
+++ b/pykrige/rk.py
@@ -23,7 +23,7 @@ threed_krige = ("ordinary3d", "universal3d")
 def validate_method(method):
     if method not in krige_methods.keys():
         raise ValueError(
-            "Kriging method must be " "one of {}".format(krige_methods.keys())
+            "Kriging method must be one of {}".format(krige_methods.keys())
         )
 
 
@@ -151,7 +151,7 @@ class Krige(RegressorMixin, BaseEstimator):
 def check_sklearn_model(model):
     if not (isinstance(model, BaseEstimator) and isinstance(model, RegressorMixin)):
         raise RuntimeError(
-            "Needs to supply an instance of a scikit-learn " "regression class."
+            "Needs to supply an instance of a scikit-learn regression class."
         )
 
 

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -241,12 +241,12 @@ class UniversalKriging:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -364,7 +364,7 @@ class UniversalKriging:
                 raise ValueError("Must specify external Z drift terms.")
             if external_drift_x is None or external_drift_y is None:
                 raise ValueError(
-                    "Must specify coordinates of " "external Z drift terms."
+                    "Must specify coordinates of external Z drift terms."
                 )
             self.external_Z_drift = True
             if (
@@ -397,7 +397,7 @@ class UniversalKriging:
         if "point_log" in drift_terms:
             if point_drift is None:
                 raise ValueError(
-                    "Must specify location(s) and strength(s) " "of point drift terms."
+                    "Must specify location(s) and strength(s) of point drift terms."
                 )
             self.point_log_drift = True
             point_log = np.atleast_2d(np.squeeze(np.array(point_drift, copy=True)))
@@ -644,12 +644,12 @@ class UniversalKriging:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -918,7 +918,7 @@ class UniversalKriging:
                 i += 1
         if i != n_withdrifts:
             warnings.warn(
-                "Error in setting up kriging system. " "Kriging may fail.",
+                "Error in setting up kriging system. Kriging may fail.",
                 RuntimeWarning,
             )
         if self.UNBIAS:
@@ -1010,7 +1010,7 @@ class UniversalKriging:
                     i += 1
             if i != n_withdrifts:
                 warnings.warn(
-                    "Error in setting up kriging system. " "Kriging may fail.",
+                    "Error in setting up kriging system. Kriging may fail.",
                     RuntimeWarning,
                 )
             if self.UNBIAS:
@@ -1117,7 +1117,7 @@ class UniversalKriging:
             print("Executing Universal Kriging...\n")
 
         if style != "grid" and style != "masked" and style != "points":
-            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         n = self.X_ADJUSTED.shape[0]
         n_withdrifts = n
@@ -1141,14 +1141,14 @@ class UniversalKriging:
             if style == "masked":
                 if mask is None:
                     raise IOError(
-                        "Must specify boolean masking array when " "style is 'masked'."
+                        "Must specify boolean masking array when style is 'masked'."
                     )
                 if mask.shape[0] != ny or mask.shape[1] != nx:
                     if mask.shape[0] == nx and mask.shape[1] == ny:
                         mask = mask.T
                     else:
                         raise ValueError(
-                            "Mask dimensions do not match " "specified grid dimensions."
+                            "Mask dimensions do not match specified grid dimensions."
                         )
                 mask = mask.flatten()
             npt = ny * nx
@@ -1165,7 +1165,7 @@ class UniversalKriging:
                 )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         if specified_drift_arrays is None:
             specified_drift_arrays = []
@@ -1215,7 +1215,7 @@ class UniversalKriging:
                         spec_drift_grids.append(np.squeeze(spec))
             if len(spec_drift_grids) != len(self.specified_drift_data_arrays):
                 raise ValueError(
-                    "Inconsistent number of specified drift " "terms supplied."
+                    "Inconsistent number of specified drift terms supplied."
                 )
         else:
             if len(specified_drift_arrays) != 0:

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -290,7 +290,11 @@ class UniversalKriging:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
             self.Z,
             self.variogram_model,
@@ -363,9 +367,7 @@ class UniversalKriging:
             if external_drift is None:
                 raise ValueError("Must specify external Z drift terms.")
             if external_drift_x is None or external_drift_y is None:
-                raise ValueError(
-                    "Must specify coordinates of external Z drift terms."
-                )
+                raise ValueError("Must specify coordinates of external Z drift terms.")
             self.external_Z_drift = True
             if (
                 external_drift.shape[0] != external_drift_y.shape[0]
@@ -678,7 +680,11 @@ class UniversalKriging:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
             self.Z,
             self.variogram_model,
@@ -918,8 +924,7 @@ class UniversalKriging:
                 i += 1
         if i != n_withdrifts:
             warnings.warn(
-                "Error in setting up kriging system. Kriging may fail.",
-                RuntimeWarning,
+                "Error in setting up kriging system. Kriging may fail.", RuntimeWarning,
             )
         if self.UNBIAS:
             b[:, n_withdrifts, 0] = 1.0

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -16,15 +16,19 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 import numpy as np
 import scipy.linalg
 from scipy.spatial.distance import cdist
 from . import variogram_models
 from . import core
-from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list, _find_statistics
+from .core import (
+    _adjust_for_anisotropy,
+    _initialize_variogram_model,
+    _make_variogram_parameter_list,
+    _find_statistics,
+)
 import warnings
 
 
@@ -175,23 +179,40 @@ class UniversalKriging:
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
     """
 
-    UNBIAS = True   # This can be changed to remove the unbiasedness condition
-                    # Really for testing purposes only...
-    eps = 1.e-10    # Cutoff for comparison to zero
-    variogram_dict = {'linear': variogram_models.linear_variogram_model,
-                      'power': variogram_models.power_variogram_model,
-                      'gaussian': variogram_models.gaussian_variogram_model,
-                      'spherical': variogram_models.spherical_variogram_model,
-                      'exponential': variogram_models.exponential_variogram_model,
-                      'hole-effect': variogram_models.hole_effect_variogram_model}
+    UNBIAS = True  # This can be changed to remove the unbiasedness condition
+    # Really for testing purposes only...
+    eps = 1.0e-10  # Cutoff for comparison to zero
+    variogram_dict = {
+        "linear": variogram_models.linear_variogram_model,
+        "power": variogram_models.power_variogram_model,
+        "gaussian": variogram_models.gaussian_variogram_model,
+        "spherical": variogram_models.spherical_variogram_model,
+        "exponential": variogram_models.exponential_variogram_model,
+        "hole-effect": variogram_models.hole_effect_variogram_model,
+    }
 
-    def __init__(self, x, y, z, variogram_model='linear',
-                 variogram_parameters=None, variogram_function=None, nlags=6,
-                 weight=False, anisotropy_scaling=1., anisotropy_angle=0.,
-                 drift_terms=None, point_drift=None, external_drift=None,
-                 external_drift_x=None, external_drift_y=None,
-                 specified_drift=None, functional_drift=None,
-                 verbose=False, enable_plotting=False):
+    def __init__(
+        self,
+        x,
+        y,
+        z,
+        variogram_model="linear",
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling=1.0,
+        anisotropy_angle=0.0,
+        drift_terms=None,
+        point_drift=None,
+        external_drift=None,
+        external_drift_x=None,
+        external_drift_y=None,
+        specified_drift=None,
+        functional_drift=None,
+        verbose=False,
+        enable_plotting=False,
+    ):
 
         # Deal with mutable default argument
         if drift_terms is None:
@@ -215,14 +236,18 @@ class UniversalKriging:
             variogram_parameters = []
             anisotropy_scaling = self.model.pykrige_anis
             anisotropy_angle = self.model.pykrige_angle
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
@@ -231,12 +256,13 @@ class UniversalKriging:
         # Code assumes 1D input arrays. Ensures that any extraneous dimensions
         # don't get in the way. Copies are created to avoid any problems with
         # referencing the original passed arguments.
-        self.X_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(x, copy=True, dtype=np.float64)))
-        self.Y_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(y, copy=True, dtype=np.float64)))
-        self.Z = \
-            np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
+        self.X_ORIG = np.atleast_1d(
+            np.squeeze(np.array(x, copy=True, dtype=np.float64))
+        )
+        self.Y_ORIG = np.atleast_1d(
+            np.squeeze(np.array(y, copy=True, dtype=np.float64))
+        )
+        self.Z = np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
 
         self.verbose = verbose
         self.enable_plotting = enable_plotting
@@ -244,68 +270,79 @@ class UniversalKriging:
             print("Plotting Enabled\n")
 
         # adjust for anisotropy...
-        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG))/2.0
-        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG))/2.0
+        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG)) / 2.0
+        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG)) / 2.0
         self.anisotropy_scaling = anisotropy_scaling
         self.anisotropy_angle = anisotropy_angle
         if self.verbose:
             print("Adjusting data for anisotropy...")
-        self.X_ADJUSTED, self.Y_ADJUSTED = \
-            _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG)).T,
-                                   [self.XCENTER, self.YCENTER],
-                                   [self.anisotropy_scaling],
-                                   [self.anisotropy_angle]).T
+        self.X_ADJUSTED, self.Y_ADJUSTED = _adjust_for_anisotropy(
+            np.vstack((self.X_ORIG, self.Y_ORIG)).T,
+            [self.XCENTER, self.YCENTER],
+            [self.anisotropy_scaling],
+            [self.anisotropy_angle],
+        ).T
 
         if self.verbose:
             print("Initializing variogram model...")
 
         # see comment in ok.py about 'use_psill' kwarg...
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED)).T,
-                                        self.Z, self.variogram_model, vp_temp,
-                                        self.variogram_function, nlags,
-                                        weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
         # TODO extend geographic capabilities to UK...
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
-                             self.Z, self.variogram_function,
-                             self.variogram_model_parameters,
-                             'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
         if self.verbose:
             print("Initializing drift terms...")
@@ -313,7 +350,7 @@ class UniversalKriging:
         # Note that the regional linear drift values will be based
         # on the adjusted coordinate system, Really, it doesn't actually
         # matter which coordinate system is used here.
-        if 'regional_linear' in drift_terms:
+        if "regional_linear" in drift_terms:
             self.regional_linear_drift = True
             if self.verbose:
                 print("Implementing regional linear drift.")
@@ -322,87 +359,110 @@ class UniversalKriging:
 
         # External Z scalars are extracted using the original
         # (unadjusted) coordinates.
-        if 'external_Z' in drift_terms:
+        if "external_Z" in drift_terms:
             if external_drift is None:
                 raise ValueError("Must specify external Z drift terms.")
             if external_drift_x is None or external_drift_y is None:
-                raise ValueError("Must specify coordinates of "
-                                 "external Z drift terms.")
+                raise ValueError(
+                    "Must specify coordinates of " "external Z drift terms."
+                )
             self.external_Z_drift = True
-            if external_drift.shape[0] != external_drift_y.shape[0] or \
-               external_drift.shape[1] != external_drift_x.shape[0]:
-                if external_drift.shape[0] == external_drift_x.shape[0] and \
-                   external_drift.shape[1] == external_drift_y.shape[0]:
+            if (
+                external_drift.shape[0] != external_drift_y.shape[0]
+                or external_drift.shape[1] != external_drift_x.shape[0]
+            ):
+                if (
+                    external_drift.shape[0] == external_drift_x.shape[0]
+                    and external_drift.shape[1] == external_drift_y.shape[0]
+                ):
                     self.external_Z_drift = np.array(external_drift.T)
                 else:
-                    raise ValueError("External drift dimensions do not match "
-                                     "provided x- and y-coordinate dimensions.")
+                    raise ValueError(
+                        "External drift dimensions do not match "
+                        "provided x- and y-coordinate dimensions."
+                    )
             else:
                 self.external_Z_array = np.array(external_drift)
             self.external_Z_array_x = np.array(external_drift_x).flatten()
             self.external_Z_array_y = np.array(external_drift_y).flatten()
-            self.z_scalars = self._calculate_data_point_zscalars(self.X_ORIG,
-                                                                 self.Y_ORIG)
+            self.z_scalars = self._calculate_data_point_zscalars(
+                self.X_ORIG, self.Y_ORIG
+            )
             if self.verbose:
                 print("Implementing external Z drift.")
         else:
             self.external_Z_drift = False
 
         # Well coordinates are rotated into adjusted coordinate frame.
-        if 'point_log' in drift_terms:
+        if "point_log" in drift_terms:
             if point_drift is None:
-                raise ValueError("Must specify location(s) and strength(s) "
-                                 "of point drift terms.")
+                raise ValueError(
+                    "Must specify location(s) and strength(s) " "of point drift terms."
+                )
             self.point_log_drift = True
             point_log = np.atleast_2d(np.squeeze(np.array(point_drift, copy=True)))
             self.point_log_array = np.zeros(point_log.shape)
             self.point_log_array[:, 2] = point_log[:, 2]
-            self.point_log_array[:, :2] = \
-                _adjust_for_anisotropy(np.vstack((point_log[:, 0],
-                                                  point_log[:, 1])).T,
-                                       [self.XCENTER, self.YCENTER],
-                                       [self.anisotropy_scaling],
-                                       [self.anisotropy_angle])
+            self.point_log_array[:, :2] = _adjust_for_anisotropy(
+                np.vstack((point_log[:, 0], point_log[:, 1])).T,
+                [self.XCENTER, self.YCENTER],
+                [self.anisotropy_scaling],
+                [self.anisotropy_angle],
+            )
             if self.verbose:
-                print("Implementing external point-logarithmic drift; "
-                      "number of points =", self.point_log_array.shape[0], '\n')
+                print(
+                    "Implementing external point-logarithmic drift; "
+                    "number of points =",
+                    self.point_log_array.shape[0],
+                    "\n",
+                )
         else:
             self.point_log_drift = False
 
-        if 'specified' in drift_terms:
+        if "specified" in drift_terms:
             if type(specified_drift) is not list:
-                raise TypeError("Arrays for specified drift terms must be "
-                                "encapsulated in a list.")
+                raise TypeError(
+                    "Arrays for specified drift terms must be "
+                    "encapsulated in a list."
+                )
             if len(specified_drift) == 0:
-                raise ValueError("Must provide at least one drift-value array "
-                                 "when using the 'specified' drift capability.")
+                raise ValueError(
+                    "Must provide at least one drift-value array "
+                    "when using the 'specified' drift capability."
+                )
             self.specified_drift = True
             self.specified_drift_data_arrays = []
             for term in specified_drift:
                 specified = np.squeeze(np.array(term, copy=True))
                 if specified.size != self.X_ORIG.size:
-                    raise ValueError("Must specify the drift values for each "
-                                     "data point when using the 'specified' "
-                                     "drift capability.")
+                    raise ValueError(
+                        "Must specify the drift values for each "
+                        "data point when using the 'specified' "
+                        "drift capability."
+                    )
                 self.specified_drift_data_arrays.append(specified)
         else:
             self.specified_drift = False
 
         # The provided callable functions will be evaluated using
         # the adjusted coordinates.
-        if 'functional' in drift_terms:
+        if "functional" in drift_terms:
             if type(functional_drift) is not list:
-                raise TypeError("Callables for functional drift terms must "
-                                "be encapsulated in a list.")
+                raise TypeError(
+                    "Callables for functional drift terms must "
+                    "be encapsulated in a list."
+                )
             if len(functional_drift) == 0:
-                raise ValueError("Must provide at least one callable object "
-                                 "when using the 'functional' drift capability.")
+                raise ValueError(
+                    "Must provide at least one callable object "
+                    "when using the 'functional' drift capability."
+                )
             self.functional_drift = True
             self.functional_drift_terms = functional_drift
         else:
             self.functional_drift = False
 
-    def _calculate_data_point_zscalars(self, x, y, type_='array'):
+    def _calculate_data_point_zscalars(self, x, y, type_="array"):
         """Determines the Z-scalar values at the specified coordinates
         for use when setting up the kriging matrix. Uses bilinear
         interpolation.
@@ -413,7 +473,7 @@ class UniversalKriging:
         Z value for that cell in the kriged grid. Rather, the exact Z value
         right at the coordinate is used."""
 
-        if type_ == 'scalar':
+        if type_ == "scalar":
             nx = 1
             ny = 1
             z_scalars = None
@@ -429,7 +489,7 @@ class UniversalKriging:
         for m in range(ny):
             for n in range(nx):
 
-                if type_ == 'scalar':
+                if type_ == "scalar":
                     xn = x
                     yn = y
                 else:
@@ -440,61 +500,78 @@ class UniversalKriging:
                         xn = x[m, n]
                         yn = y[m, n]
 
-                if xn > np.amax(self.external_Z_array_x) or \
-                   xn < np.amin(self.external_Z_array_x) or \
-                   yn > np.amax(self.external_Z_array_y) or \
-                   yn < np.amin(self.external_Z_array_y):
-                    raise ValueError("External drift array does not cover "
-                                     "specified kriging domain.")
+                if (
+                    xn > np.amax(self.external_Z_array_x)
+                    or xn < np.amin(self.external_Z_array_x)
+                    or yn > np.amax(self.external_Z_array_y)
+                    or yn < np.amin(self.external_Z_array_y)
+                ):
+                    raise ValueError(
+                        "External drift array does not cover "
+                        "specified kriging domain."
+                    )
 
                 # bilinear interpolation
-                external_x2_index = \
-                    np.amin(np.where(self.external_Z_array_x >= xn)[0])
-                external_x1_index = \
-                    np.amax(np.where(self.external_Z_array_x <= xn)[0])
-                external_y2_index = \
-                    np.amin(np.where(self.external_Z_array_y >= yn)[0])
-                external_y1_index = \
-                    np.amax(np.where(self.external_Z_array_y <= yn)[0])
+                external_x2_index = np.amin(np.where(self.external_Z_array_x >= xn)[0])
+                external_x1_index = np.amax(np.where(self.external_Z_array_x <= xn)[0])
+                external_y2_index = np.amin(np.where(self.external_Z_array_y >= yn)[0])
+                external_y1_index = np.amax(np.where(self.external_Z_array_y <= yn)[0])
                 if external_y1_index == external_y2_index:
                     if external_x1_index == external_x2_index:
                         z = self.external_Z_array[external_y1_index, external_x1_index]
                     else:
-                        z = (self.external_Z_array[external_y1_index, external_x1_index] *
-                             (self.external_Z_array_x[external_x2_index] - xn) +
-                             self.external_Z_array[external_y2_index, external_x2_index] *
-                             (xn - self.external_Z_array_x[external_x1_index])) / \
-                            (self.external_Z_array_x[external_x2_index] -
-                             self.external_Z_array_x[external_x1_index])
+                        z = (
+                            self.external_Z_array[external_y1_index, external_x1_index]
+                            * (self.external_Z_array_x[external_x2_index] - xn)
+                            + self.external_Z_array[
+                                external_y2_index, external_x2_index
+                            ]
+                            * (xn - self.external_Z_array_x[external_x1_index])
+                        ) / (
+                            self.external_Z_array_x[external_x2_index]
+                            - self.external_Z_array_x[external_x1_index]
+                        )
                 elif external_x1_index == external_x2_index:
                     if external_y1_index == external_y2_index:
                         z = self.external_Z_array[external_y1_index, external_x1_index]
                     else:
-                        z = (self.external_Z_array[external_y1_index, external_x1_index] *
-                             (self.external_Z_array_y[external_y2_index] - yn) +
-                             self.external_Z_array[external_y2_index, external_x2_index] *
-                             (yn - self.external_Z_array_y[external_y1_index])) / \
-                            (self.external_Z_array_y[external_y2_index] -
-                             self.external_Z_array_y[external_y1_index])
+                        z = (
+                            self.external_Z_array[external_y1_index, external_x1_index]
+                            * (self.external_Z_array_y[external_y2_index] - yn)
+                            + self.external_Z_array[
+                                external_y2_index, external_x2_index
+                            ]
+                            * (yn - self.external_Z_array_y[external_y1_index])
+                        ) / (
+                            self.external_Z_array_y[external_y2_index]
+                            - self.external_Z_array_y[external_y1_index]
+                        )
                 else:
-                    z = (self.external_Z_array[external_y1_index, external_x1_index] *
-                         (self.external_Z_array_x[external_x2_index] - xn) *
-                         (self.external_Z_array_y[external_y2_index] - yn) +
-                         self.external_Z_array[external_y1_index, external_x2_index] *
-                         (xn - self.external_Z_array_x[external_x1_index]) *
-                         (self.external_Z_array_y[external_y2_index] - yn) +
-                         self.external_Z_array[external_y2_index, external_x1_index] *
-                         (self.external_Z_array_x[external_x2_index] - xn) *
-                         (yn - self.external_Z_array_y[external_y1_index]) +
-                         self.external_Z_array[external_y2_index, external_x2_index] *
-                         (xn - self.external_Z_array_x[external_x1_index]) *
-                         (yn - self.external_Z_array_y[external_y1_index])) / \
-                        ((self.external_Z_array_x[external_x2_index] -
-                          self.external_Z_array_x[external_x1_index]) *
-                         (self.external_Z_array_y[external_y2_index] -
-                          self.external_Z_array_y[external_y1_index]))
+                    z = (
+                        self.external_Z_array[external_y1_index, external_x1_index]
+                        * (self.external_Z_array_x[external_x2_index] - xn)
+                        * (self.external_Z_array_y[external_y2_index] - yn)
+                        + self.external_Z_array[external_y1_index, external_x2_index]
+                        * (xn - self.external_Z_array_x[external_x1_index])
+                        * (self.external_Z_array_y[external_y2_index] - yn)
+                        + self.external_Z_array[external_y2_index, external_x1_index]
+                        * (self.external_Z_array_x[external_x2_index] - xn)
+                        * (yn - self.external_Z_array_y[external_y1_index])
+                        + self.external_Z_array[external_y2_index, external_x2_index]
+                        * (xn - self.external_Z_array_x[external_x1_index])
+                        * (yn - self.external_Z_array_y[external_y1_index])
+                    ) / (
+                        (
+                            self.external_Z_array_x[external_x2_index]
+                            - self.external_Z_array_x[external_x1_index]
+                        )
+                        * (
+                            self.external_Z_array_y[external_y2_index]
+                            - self.external_Z_array_y[external_y1_index]
+                        )
+                    )
 
-                if type_ == 'scalar':
+                if type_ == "scalar":
                     z_scalars = z
                 else:
                     if z_scalars.ndim == 1:
@@ -504,9 +581,16 @@ class UniversalKriging:
 
         return z_scalars
 
-    def update_variogram_model(self, variogram_model, variogram_parameters=None,
-                               variogram_function=None, nlags=6, weight=False,
-                               anisotropy_scaling=1., anisotropy_angle=0.):
+    def update_variogram_model(
+        self,
+        variogram_model,
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling=1.0,
+        anisotropy_angle=0.0,
+    ):
         """Allows user to update variogram type and/or
         variogram model parameters.
 
@@ -555,80 +639,97 @@ class UniversalKriging:
             variogram_parameters = []
             anisotropy_scaling = self.model.pykrige_anis
             anisotropy_angle = self.model.pykrige_angle
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
             self.variogram_function = self.variogram_dict[self.variogram_model]
 
-        if anisotropy_scaling != self.anisotropy_scaling or \
-           anisotropy_angle != self.anisotropy_angle:
+        if (
+            anisotropy_scaling != self.anisotropy_scaling
+            or anisotropy_angle != self.anisotropy_angle
+        ):
             if self.verbose:
                 print("Adjusting data for anisotropy...")
             self.anisotropy_scaling = anisotropy_scaling
             self.anisotropy_angle = anisotropy_angle
-            self.X_ADJUSTED, self.Y_ADJUSTED =\
-                _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG)).T,
-                                       [self.XCENTER, self.YCENTER],
-                                       [self.anisotropy_scaling],
-                                       [self.anisotropy_angle]).T
+            self.X_ADJUSTED, self.Y_ADJUSTED = _adjust_for_anisotropy(
+                np.vstack((self.X_ORIG, self.Y_ORIG)).T,
+                [self.XCENTER, self.YCENTER],
+                [self.anisotropy_scaling],
+                [self.anisotropy_angle],
+            ).T
 
         if self.verbose:
             print("Updating variogram mode...")
 
         # See note above about the 'use_psill' kwarg...
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED)).T,
-                                        self.Z, self.variogram_model, vp_temp,
-                                        self.variogram_function, nlags,
-                                        weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
-                             self.Z, self.variogram_function,
-                             self.variogram_model_parameters,
-                             'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED)).T,
+            self.Z,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
     def display_variogram_model(self):
         """Displays variogram model with the actual binned data."""
@@ -636,10 +737,12 @@ class UniversalKriging:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(self.lags, self.semivariance, 'r*')
-        ax.plot(self.lags,
-                self.variogram_function(self.variogram_model_parameters,
-                                        self.lags), 'k-')
+        ax.plot(self.lags, self.semivariance, "r*")
+        ax.plot(
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+            "k-",
+        )
         plt.show()
 
     def get_variogram_points(self):
@@ -657,7 +760,10 @@ class UniversalKriging:
             lags (array) - the lags at which the variogram was evaluated
             variogram (array) - the variogram function evaluated at the lags
         """
-        return self.lags, self.variogram_function(self.variogram_model_parameters, self.lags)
+        return (
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+        )
 
     def switch_verbose(self):
         """Allows user to switch code talk-back on/off. Takes no arguments."""
@@ -677,7 +783,7 @@ class UniversalKriging:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.scatter(range(self.epsilon.size), self.epsilon, c='k', marker='*')
+        ax.scatter(range(self.epsilon.size), self.epsilon, c="k", marker="*")
         ax.axhline(y=0.0)
         plt.show()
 
@@ -699,15 +805,16 @@ class UniversalKriging:
     def _get_kriging_matrix(self, n, n_withdrifts):
         """Assembles the kriging matrix."""
 
-        xy = np.concatenate((self.X_ADJUSTED[:, np.newaxis],
-                             self.Y_ADJUSTED[:, np.newaxis]), axis=1)
-        d = cdist(xy, xy, 'euclidean')
+        xy = np.concatenate(
+            (self.X_ADJUSTED[:, np.newaxis], self.Y_ADJUSTED[:, np.newaxis]), axis=1
+        )
+        d = cdist(xy, xy, "euclidean")
         if self.UNBIAS:
-            a = np.zeros((n_withdrifts+1, n_withdrifts+1))
+            a = np.zeros((n_withdrifts + 1, n_withdrifts + 1))
         else:
             a = np.zeros((n_withdrifts, n_withdrifts))
-        a[:n, :n] = - self.variogram_function(self.variogram_model_parameters, d)
-        np.fill_diagonal(a, 0.)
+        a[:n, :n] = -self.variogram_function(self.variogram_model_parameters, d)
+        np.fill_diagonal(a, 0.0)
 
         i = n
         if self.regional_linear_drift:
@@ -719,12 +826,16 @@ class UniversalKriging:
             i += 1
         if self.point_log_drift:
             for well_no in range(self.point_log_array.shape[0]):
-                log_dist = np.log(np.sqrt((self.X_ADJUSTED - self.point_log_array[well_no, 0])**2 +
-                                          (self.Y_ADJUSTED - self.point_log_array[well_no, 1])**2))
+                log_dist = np.log(
+                    np.sqrt(
+                        (self.X_ADJUSTED - self.point_log_array[well_no, 0]) ** 2
+                        + (self.Y_ADJUSTED - self.point_log_array[well_no, 1]) ** 2
+                    )
+                )
                 if np.any(np.isinf(log_dist)):
                     log_dist[np.isinf(log_dist)] = -100.0
-                a[:n, i] = - self.point_log_array[well_no, 2] * log_dist
-                a[i, :n] = - self.point_log_array[well_no, 2] * log_dist
+                a[:n, i] = -self.point_log_array[well_no, 2] * log_dist
+                a[i, :n] = -self.point_log_array[well_no, 2] * log_dist
                 i += 1
         if self.external_Z_drift:
             a[:n, i] = self.z_scalars
@@ -741,17 +852,17 @@ class UniversalKriging:
                 a[i, :n] = func(self.X_ADJUSTED, self.Y_ADJUSTED)
                 i += 1
         if i != n_withdrifts:
-            warnings.warn("Error in creating kriging matrix. Kriging may fail.",
-                          RuntimeWarning)
+            warnings.warn(
+                "Error in creating kriging matrix. Kriging may fail.", RuntimeWarning
+            )
         if self.UNBIAS:
             a[n_withdrifts, :n] = 1.0
             a[:n, n_withdrifts] = 1.0
-            a[n:n_withdrifts + 1, n:n_withdrifts + 1] = 0.0
+            a[n : n_withdrifts + 1, n : n_withdrifts + 1] = 0.0
 
         return a
 
-    def _exec_vector(self, a, bd, xy, xy_orig, mask,
-                     n_withdrifts, spec_drift_grids):
+    def _exec_vector(self, a, bd, xy, xy_orig, mask, n_withdrifts, spec_drift_grids):
         """Solves the kriging system as a vectorized operation. This method
         can take a lot of memory for large grids and/or large datasets."""
 
@@ -767,10 +878,10 @@ class UniversalKriging:
             zero_index = np.where(np.absolute(bd) <= self.eps)
 
         if self.UNBIAS:
-            b = np.zeros((npt, n_withdrifts+1, 1))
+            b = np.zeros((npt, n_withdrifts + 1, 1))
         else:
             b = np.zeros((npt, n_withdrifts, 1))
-        b[:, :n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+        b[:, :n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
         if zero_value:
             b[zero_index[0], zero_index[1], 0] = 0.0
 
@@ -782,14 +893,20 @@ class UniversalKriging:
             i += 1
         if self.point_log_drift:
             for well_no in range(self.point_log_array.shape[0]):
-                log_dist = np.log(np.sqrt((xy[:, 0] - self.point_log_array[well_no, 0])**2 +
-                                          (xy[:, 1] - self.point_log_array[well_no, 1])**2))
+                log_dist = np.log(
+                    np.sqrt(
+                        (xy[:, 0] - self.point_log_array[well_no, 0]) ** 2
+                        + (xy[:, 1] - self.point_log_array[well_no, 1]) ** 2
+                    )
+                )
                 if np.any(np.isinf(log_dist)):
                     log_dist[np.isinf(log_dist)] = -100.0
-                b[:, i, 0] = - self.point_log_array[well_no, 2] * log_dist
+                b[:, i, 0] = -self.point_log_array[well_no, 2] * log_dist
                 i += 1
         if self.external_Z_drift:
-            b[:, i, 0] = self._calculate_data_point_zscalars(xy_orig[:, 0], xy_orig[:, 1])
+            b[:, i, 0] = self._calculate_data_point_zscalars(
+                xy_orig[:, 0], xy_orig[:, 1]
+            )
             i += 1
         if self.specified_drift:
             for spec_vals in spec_drift_grids:
@@ -800,27 +917,37 @@ class UniversalKriging:
                 b[:, i, 0] = func(xy[:, 0], xy[:, 1])
                 i += 1
         if i != n_withdrifts:
-            warnings.warn("Error in setting up kriging system. "
-                          "Kriging may fail.", RuntimeWarning)
+            warnings.warn(
+                "Error in setting up kriging system. " "Kriging may fail.",
+                RuntimeWarning,
+            )
         if self.UNBIAS:
             b[:, n_withdrifts, 0] = 1.0
 
         if (~mask).any():
-            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis],
-                               n_withdrifts+1, axis=1)
+            mask_b = np.repeat(
+                mask[:, np.newaxis, np.newaxis], n_withdrifts + 1, axis=1
+            )
             b = np.ma.array(b, mask=mask_b)
 
         if self.UNBIAS:
-            x = np.dot(a_inv, b.reshape((npt, n_withdrifts+1)).T).reshape((1, n_withdrifts+1, npt)).T
+            x = (
+                np.dot(a_inv, b.reshape((npt, n_withdrifts + 1)).T)
+                .reshape((1, n_withdrifts + 1, npt))
+                .T
+            )
         else:
-            x = np.dot(a_inv, b.reshape((npt, n_withdrifts)).T).reshape((1, n_withdrifts, npt)).T
+            x = (
+                np.dot(a_inv, b.reshape((npt, n_withdrifts)).T)
+                .reshape((1, n_withdrifts, npt))
+                .T
+            )
         zvalues = np.sum(x[:, :n, 0] * self.Z, axis=1)
         sigmasq = np.sum(x[:, :, 0] * -b[:, :, 0], axis=1)
 
         return zvalues, sigmasq
 
-    def _exec_loop(self, a, bd_all, xy, xy_orig, mask,
-                   n_withdrifts, spec_drift_grids):
+    def _exec_loop(self, a, bd_all, xy, xy_orig, mask, n_withdrifts, spec_drift_grids):
         """Solves the kriging system by looping over all specified points.
         Less memory-intensive, but involves a Python-level loop."""
 
@@ -831,8 +958,10 @@ class UniversalKriging:
 
         a_inv = scipy.linalg.inv(a)
 
-        for j in np.nonzero(~mask)[0]:   # Note that this is the same thing as range(npt) if mask is not defined,
-            bd = bd_all[j]               # otherwise it takes the non-masked elements.
+        for j in np.nonzero(~mask)[
+            0
+        ]:  # Note that this is the same thing as range(npt) if mask is not defined,
+            bd = bd_all[j]  # otherwise it takes the non-masked elements.
             if np.any(np.absolute(bd) <= self.eps):
                 zero_value = True
                 zero_index = np.where(np.absolute(bd) <= self.eps)
@@ -841,10 +970,10 @@ class UniversalKriging:
                 zero_value = False
 
             if self.UNBIAS:
-                b = np.zeros((n_withdrifts+1, 1))
+                b = np.zeros((n_withdrifts + 1, 1))
             else:
                 b = np.zeros((n_withdrifts, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
 
@@ -856,14 +985,20 @@ class UniversalKriging:
                 i += 1
             if self.point_log_drift:
                 for well_no in range(self.point_log_array.shape[0]):
-                    log_dist = np.log(np.sqrt((xy[j, 0] - self.point_log_array[well_no, 0])**2 +
-                                              (xy[j, 1] - self.point_log_array[well_no, 1])**2))
+                    log_dist = np.log(
+                        np.sqrt(
+                            (xy[j, 0] - self.point_log_array[well_no, 0]) ** 2
+                            + (xy[j, 1] - self.point_log_array[well_no, 1]) ** 2
+                        )
+                    )
                     if np.any(np.isinf(log_dist)):
                         log_dist[np.isinf(log_dist)] = -100.0
-                    b[i, 0] = - self.point_log_array[well_no, 2] * log_dist
+                    b[i, 0] = -self.point_log_array[well_no, 2] * log_dist
                     i += 1
             if self.external_Z_drift:
-                b[i, 0] = self._calculate_data_point_zscalars(xy_orig[j, 0], xy_orig[j, 1], type_='scalar')
+                b[i, 0] = self._calculate_data_point_zscalars(
+                    xy_orig[j, 0], xy_orig[j, 1], type_="scalar"
+                )
                 i += 1
             if self.specified_drift:
                 for spec_vals in spec_drift_grids:
@@ -874,8 +1009,10 @@ class UniversalKriging:
                     b[i, 0] = func(xy[j, 0], xy[j, 1])
                     i += 1
             if i != n_withdrifts:
-                warnings.warn("Error in setting up kriging system. "
-                              "Kriging may fail.", RuntimeWarning)
+                warnings.warn(
+                    "Error in setting up kriging system. " "Kriging may fail.",
+                    RuntimeWarning,
+                )
             if self.UNBIAS:
                 b[n_withdrifts, 0] = 1.0
 
@@ -885,8 +1022,15 @@ class UniversalKriging:
 
         return zvalues, sigmasq
 
-    def execute(self, style, xpoints, ypoints, mask=None,
-                backend='vectorized', specified_drift_arrays=None):
+    def execute(
+        self,
+        style,
+        xpoints,
+        ypoints,
+        mask=None,
+        backend="vectorized",
+        specified_drift_arrays=None,
+    ):
         """Calculates a kriged grid and the associated variance.
         Includes drift terms.
 
@@ -972,9 +1116,8 @@ class UniversalKriging:
         if self.verbose:
             print("Executing Universal Kriging...\n")
 
-        if style != 'grid' and style != 'masked' and style != 'points':
-            raise ValueError("style argument must be 'grid', 'points', "
-                             "or 'masked'")
+        if style != "grid" and style != "masked" and style != "points":
+            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
 
         n = self.X_ADJUSTED.shape[0]
         n_withdrifts = n
@@ -994,111 +1137,144 @@ class UniversalKriging:
             n_withdrifts += len(self.functional_drift_terms)
         a = self._get_kriging_matrix(n, n_withdrifts)
 
-        if style in ['grid', 'masked']:
-            if style == 'masked':
+        if style in ["grid", "masked"]:
+            if style == "masked":
                 if mask is None:
-                    raise IOError("Must specify boolean masking array when "
-                                  "style is 'masked'.")
+                    raise IOError(
+                        "Must specify boolean masking array when " "style is 'masked'."
+                    )
                 if mask.shape[0] != ny or mask.shape[1] != nx:
                     if mask.shape[0] == nx and mask.shape[1] == ny:
                         mask = mask.T
                     else:
-                        raise ValueError("Mask dimensions do not match "
-                                         "specified grid dimensions.")
+                        raise ValueError(
+                            "Mask dimensions do not match " "specified grid dimensions."
+                        )
                 mask = mask.flatten()
-            npt = ny*nx
+            npt = ny * nx
             grid_x, grid_y = np.meshgrid(xpts, ypts)
             xpts = grid_x.flatten()
             ypts = grid_y.flatten()
 
-        elif style == 'points':
+        elif style == "points":
             if xpts.size != ypts.size:
-                raise ValueError("xpoints and ypoints must have same "
-                                 "dimensions when treated as listing "
-                                 "discrete points.")
+                raise ValueError(
+                    "xpoints and ypoints must have same "
+                    "dimensions when treated as listing "
+                    "discrete points."
+                )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', 'points', "
-                             "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
 
         if specified_drift_arrays is None:
             specified_drift_arrays = []
         spec_drift_grids = []
         if self.specified_drift:
             if len(specified_drift_arrays) == 0:
-                raise ValueError("Must provide drift values for kriging points "
-                                 "when using 'specified' drift capability.")
+                raise ValueError(
+                    "Must provide drift values for kriging points "
+                    "when using 'specified' drift capability."
+                )
             if type(specified_drift_arrays) is not list:
-                raise TypeError("Arrays for specified drift terms must be "
-                                "encapsulated in a list.")
+                raise TypeError(
+                    "Arrays for specified drift terms must be "
+                    "encapsulated in a list."
+                )
             for spec in specified_drift_arrays:
-                if style in ['grid', 'masked']:
+                if style in ["grid", "masked"]:
                     if spec.ndim < 2:
-                        raise ValueError("Dimensions of drift values array do "
-                                         "not match specified grid dimensions.")
+                        raise ValueError(
+                            "Dimensions of drift values array do "
+                            "not match specified grid dimensions."
+                        )
                     elif spec.shape[0] != ny or spec.shape[1] != nx:
                         if spec.shape[0] == nx and spec.shape[1] == ny:
                             spec_drift_grids.append(np.squeeze(spec.T))
                         else:
-                            raise ValueError("Dimensions of drift values array "
-                                             "do not match specified grid "
-                                             "dimensions.")
+                            raise ValueError(
+                                "Dimensions of drift values array "
+                                "do not match specified grid "
+                                "dimensions."
+                            )
                     else:
                         spec_drift_grids.append(np.squeeze(spec))
-                elif style == 'points':
+                elif style == "points":
                     if spec.ndim != 1:
-                        raise ValueError("Dimensions of drift values array do "
-                                         "not match specified grid dimensions.")
+                        raise ValueError(
+                            "Dimensions of drift values array do "
+                            "not match specified grid dimensions."
+                        )
                     elif spec.shape[0] != xpts.size:
-                        raise ValueError("Number of supplied drift values in "
-                                         "array do not match specified number "
-                                         "of kriging points.")
+                        raise ValueError(
+                            "Number of supplied drift values in "
+                            "array do not match specified number "
+                            "of kriging points."
+                        )
                     else:
                         spec_drift_grids.append(np.squeeze(spec))
             if len(spec_drift_grids) != len(self.specified_drift_data_arrays):
-                raise ValueError("Inconsistent number of specified drift "
-                                 "terms supplied.")
+                raise ValueError(
+                    "Inconsistent number of specified drift " "terms supplied."
+                )
         else:
             if len(specified_drift_arrays) != 0:
-                warnings.warn("Provided specified drift values, but "
-                              "'specified' drift was not initialized during "
-                              "instantiation of UniversalKriging class.",
-                              RuntimeWarning)
+                warnings.warn(
+                    "Provided specified drift values, but "
+                    "'specified' drift was not initialized during "
+                    "instantiation of UniversalKriging class.",
+                    RuntimeWarning,
+                )
 
-        xy_points_original = \
-            np.concatenate((xpts[:, np.newaxis], ypts[:, np.newaxis]), axis=1)
-        xpts, ypts = _adjust_for_anisotropy(np.vstack((xpts, ypts)).T,
-                                            [self.XCENTER, self.YCENTER],
-                                            [self.anisotropy_scaling],
-                                            [self.anisotropy_angle]).T
-        xy_points = \
-            np.concatenate((xpts[:, np.newaxis], ypts[:, np.newaxis]), axis=1)
-        xy_data = np.concatenate((self.X_ADJUSTED[:, np.newaxis],
-                                  self.Y_ADJUSTED[:, np.newaxis]), axis=1)
+        xy_points_original = np.concatenate(
+            (xpts[:, np.newaxis], ypts[:, np.newaxis]), axis=1
+        )
+        xpts, ypts = _adjust_for_anisotropy(
+            np.vstack((xpts, ypts)).T,
+            [self.XCENTER, self.YCENTER],
+            [self.anisotropy_scaling],
+            [self.anisotropy_angle],
+        ).T
+        xy_points = np.concatenate((xpts[:, np.newaxis], ypts[:, np.newaxis]), axis=1)
+        xy_data = np.concatenate(
+            (self.X_ADJUSTED[:, np.newaxis], self.Y_ADJUSTED[:, np.newaxis]), axis=1
+        )
 
-        if style != 'masked':
-            mask = np.zeros(npt, dtype='bool')
+        if style != "masked":
+            mask = np.zeros(npt, dtype="bool")
 
-        bd = cdist(xy_points,  xy_data, 'euclidean')
-        if backend == 'vectorized':
-            zvalues, sigmasq = self._exec_vector(a, bd, xy_points,
-                                                 xy_points_original,
-                                                 mask, n_withdrifts,
-                                                 spec_drift_grids)
-        elif backend == 'loop':
-            zvalues, sigmasq = self._exec_loop(a, bd, xy_points,
-                                               xy_points_original,
-                                               mask, n_withdrifts,
-                                               spec_drift_grids)
+        bd = cdist(xy_points, xy_data, "euclidean")
+        if backend == "vectorized":
+            zvalues, sigmasq = self._exec_vector(
+                a,
+                bd,
+                xy_points,
+                xy_points_original,
+                mask,
+                n_withdrifts,
+                spec_drift_grids,
+            )
+        elif backend == "loop":
+            zvalues, sigmasq = self._exec_loop(
+                a,
+                bd,
+                xy_points,
+                xy_points_original,
+                mask,
+                n_withdrifts,
+                spec_drift_grids,
+            )
         else:
-            raise ValueError('Specified backend {} is not supported '
-                             'for 2D universal kriging.'.format(backend))
+            raise ValueError(
+                "Specified backend {} is not supported "
+                "for 2D universal kriging.".format(backend)
+            )
 
-        if style == 'masked':
+        if style == "masked":
             zvalues = np.ma.array(zvalues, mask=mask)
             sigmasq = np.ma.array(sigmasq, mask=mask)
 
-        if style in ['masked', 'grid']:
+        if style in ["masked", "grid"]:
             zvalues = zvalues.reshape((ny, nx))
             sigmasq = sigmasq.reshape((ny, nx))
 

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -294,7 +294,11 @@ class UniversalKriging3D:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
             self.VALUES,
             self.variogram_model,
@@ -529,7 +533,11 @@ class UniversalKriging3D:
         vp_temp = _make_variogram_parameter_list(
             self.variogram_model, variogram_parameters
         )
-        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+        (
+            self.lags,
+            self.semivariance,
+            self.variogram_model_parameters,
+        ) = _initialize_variogram_model(
             np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
             self.VALUES,
             self.variogram_model,
@@ -725,8 +733,7 @@ class UniversalKriging3D:
                 i += 1
         if i != n_withdrifts:
             warnings.warn(
-                "Error in setting up kriging system. Kriging may fail.",
-                RuntimeWarning,
+                "Error in setting up kriging system. Kriging may fail.", RuntimeWarning,
             )
         if self.UNBIAS:
             b[:, n_withdrifts, 0] = 1.0

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -15,15 +15,19 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 import numpy as np
 import scipy.linalg
 from scipy.spatial.distance import cdist
 from . import variogram_models
 from . import core
-from .core import _adjust_for_anisotropy, _initialize_variogram_model, \
-    _make_variogram_parameter_list, _find_statistics
+from .core import (
+    _adjust_for_anisotropy,
+    _initialize_variogram_model,
+    _make_variogram_parameter_list,
+    _find_statistics,
+)
 import warnings
 
 
@@ -169,22 +173,40 @@ class UniversalKriging3D:
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
     """
 
-    UNBIAS = True   # This can be changed to remove the unbiasedness condition
-                    # Really for testing purposes only...
-    eps = 1.e-10    # Cutoff for comparison to zero
-    variogram_dict = {'linear': variogram_models.linear_variogram_model,
-                      'power': variogram_models.power_variogram_model,
-                      'gaussian': variogram_models.gaussian_variogram_model,
-                      'spherical': variogram_models.spherical_variogram_model,
-                      'exponential': variogram_models.exponential_variogram_model,
-                      'hole-effect': variogram_models.hole_effect_variogram_model}
+    UNBIAS = True  # This can be changed to remove the unbiasedness condition
+    # Really for testing purposes only...
+    eps = 1.0e-10  # Cutoff for comparison to zero
+    variogram_dict = {
+        "linear": variogram_models.linear_variogram_model,
+        "power": variogram_models.power_variogram_model,
+        "gaussian": variogram_models.gaussian_variogram_model,
+        "spherical": variogram_models.spherical_variogram_model,
+        "exponential": variogram_models.exponential_variogram_model,
+        "hole-effect": variogram_models.hole_effect_variogram_model,
+    }
 
-    def __init__(self, x, y, z, val, variogram_model='linear',
-                 variogram_parameters=None, variogram_function=None, nlags=6,
-                 weight=False, anisotropy_scaling_y=1., anisotropy_scaling_z=1.,
-                 anisotropy_angle_x=0., anisotropy_angle_y=0.,
-                 anisotropy_angle_z=0., drift_terms=None, specified_drift=None,
-                 functional_drift=None, verbose=False, enable_plotting=False):
+    def __init__(
+        self,
+        x,
+        y,
+        z,
+        val,
+        variogram_model="linear",
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling_y=1.0,
+        anisotropy_scaling_z=1.0,
+        anisotropy_angle_x=0.0,
+        anisotropy_angle_y=0.0,
+        anisotropy_angle_z=0.0,
+        drift_terms=None,
+        specified_drift=None,
+        functional_drift=None,
+        verbose=False,
+        enable_plotting=False,
+    ):
 
         # Deal with mutable default argument
         if drift_terms is None:
@@ -211,14 +233,18 @@ class UniversalKriging3D:
             anisotropy_angle_x = self.model.pykrige_angle_x
             anisotropy_angle_y = self.model.pykrige_angle_y
             anisotropy_angle_z = self.model.pykrige_angle_z
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
@@ -227,23 +253,27 @@ class UniversalKriging3D:
         # Code assumes 1D input arrays. Ensures that any extraneous dimensions
         # don't get in the way. Copies are created to avoid any problems with
         # referencing the original passed arguments.
-        self.X_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(x, copy=True, dtype=np.float64)))
-        self.Y_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(y, copy=True, dtype=np.float64)))
-        self.Z_ORIG = \
-            np.atleast_1d(np.squeeze(np.array(z, copy=True, dtype=np.float64)))
-        self.VALUES = \
-            np.atleast_1d(np.squeeze(np.array(val, copy=True, dtype=np.float64)))
+        self.X_ORIG = np.atleast_1d(
+            np.squeeze(np.array(x, copy=True, dtype=np.float64))
+        )
+        self.Y_ORIG = np.atleast_1d(
+            np.squeeze(np.array(y, copy=True, dtype=np.float64))
+        )
+        self.Z_ORIG = np.atleast_1d(
+            np.squeeze(np.array(z, copy=True, dtype=np.float64))
+        )
+        self.VALUES = np.atleast_1d(
+            np.squeeze(np.array(val, copy=True, dtype=np.float64))
+        )
 
         self.verbose = verbose
         self.enable_plotting = enable_plotting
         if self.enable_plotting and self.verbose:
             print("Plotting Enabled\n")
 
-        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG))/2.0
-        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG))/2.0
-        self.ZCENTER = (np.amax(self.Z_ORIG) + np.amin(self.Z_ORIG))/2.0
+        self.XCENTER = (np.amax(self.X_ORIG) + np.amin(self.X_ORIG)) / 2.0
+        self.YCENTER = (np.amax(self.Y_ORIG) + np.amin(self.Y_ORIG)) / 2.0
+        self.ZCENTER = (np.amax(self.Z_ORIG) + np.amin(self.Z_ORIG)) / 2.0
         self.anisotropy_scaling_y = anisotropy_scaling_y
         self.anisotropy_scaling_z = anisotropy_scaling_z
         self.anisotropy_angle_x = anisotropy_angle_x
@@ -251,62 +281,71 @@ class UniversalKriging3D:
         self.anisotropy_angle_z = anisotropy_angle_z
         if self.verbose:
             print("Adjusting data for anisotropy...")
-        self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = \
-            _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
-                                   [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                   [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                   [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z]).T
+        self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = _adjust_for_anisotropy(
+            np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
+            [self.XCENTER, self.YCENTER, self.ZCENTER],
+            [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+            [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z],
+        ).T
 
         if self.verbose:
             print("Initializing variogram model...")
 
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED,
-                                                   self.Z_ADJUSTED)).T,
-                                        self.VALUES, self.variogram_model,
-                                        vp_temp, self.variogram_function,
-                                        nlags, weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED,
-                                        self.Y_ADJUSTED,
-                                        self.Z_ADJUSTED)).T,
-                             self.VALUES, self.variogram_function,
-                             self.variogram_model_parameters, 'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
         if self.verbose:
             print("Initializing drift terms...")
@@ -314,51 +353,69 @@ class UniversalKriging3D:
         # Note that the regional linear drift values will be based on the
         # adjusted coordinate system. Really, it doesn't actually matter
         # which coordinate system is used here.
-        if 'regional_linear' in drift_terms:
+        if "regional_linear" in drift_terms:
             self.regional_linear_drift = True
             if self.verbose:
                 print("Implementing regional linear drift.")
         else:
             self.regional_linear_drift = False
 
-        if 'specified' in drift_terms:
+        if "specified" in drift_terms:
             if type(specified_drift) is not list:
-                raise TypeError("Arrays for specified drift terms must be "
-                                "encapsulated in a list.")
+                raise TypeError(
+                    "Arrays for specified drift terms must be "
+                    "encapsulated in a list."
+                )
             if len(specified_drift) == 0:
-                raise ValueError("Must provide at least one drift-value array "
-                                 "when using the 'specified' drift capability.")
+                raise ValueError(
+                    "Must provide at least one drift-value array "
+                    "when using the 'specified' drift capability."
+                )
             self.specified_drift = True
             self.specified_drift_data_arrays = []
             for term in specified_drift:
                 specified = np.squeeze(np.array(term, copy=True))
                 if specified.size != self.X_ORIG.size:
-                    raise ValueError("Must specify the drift values for each "
-                                     "data point when using the "
-                                     "'specified' drift capability.")
+                    raise ValueError(
+                        "Must specify the drift values for each "
+                        "data point when using the "
+                        "'specified' drift capability."
+                    )
                 self.specified_drift_data_arrays.append(specified)
         else:
             self.specified_drift = False
 
         # The provided callable functions will be evaluated using
         # the adjusted coordinates.
-        if 'functional' in drift_terms:
+        if "functional" in drift_terms:
             if type(functional_drift) is not list:
-                raise TypeError("Callables for functional drift terms must "
-                                "be encapsulated in a list.")
+                raise TypeError(
+                    "Callables for functional drift terms must "
+                    "be encapsulated in a list."
+                )
             if len(functional_drift) == 0:
-                raise ValueError("Must provide at least one callable object "
-                                 "when using the 'functional' drift capability.")
+                raise ValueError(
+                    "Must provide at least one callable object "
+                    "when using the 'functional' drift capability."
+                )
             self.functional_drift = True
             self.functional_drift_terms = functional_drift
         else:
             self.functional_drift = False
 
-    def update_variogram_model(self, variogram_model, variogram_parameters=None,
-                               variogram_function=None, nlags=6, weight=False,
-                               anisotropy_scaling_y=1., anisotropy_scaling_z=1.,
-                               anisotropy_angle_x=0., anisotropy_angle_y=0.,
-                               anisotropy_angle_z=0.):
+    def update_variogram_model(
+        self,
+        variogram_model,
+        variogram_parameters=None,
+        variogram_function=None,
+        nlags=6,
+        weight=False,
+        anisotropy_scaling_y=1.0,
+        anisotropy_scaling_z=1.0,
+        anisotropy_angle_x=0.0,
+        anisotropy_angle_y=0.0,
+        anisotropy_angle_z=0.0,
+    ):
         """Changes the variogram model and variogram parameters
         for the kriging system.
 
@@ -424,24 +481,30 @@ class UniversalKriging3D:
             anisotropy_angle_x = self.model.pykrige_angle_x
             anisotropy_angle_y = self.model.pykrige_angle_y
             anisotropy_angle_z = self.model.pykrige_angle_z
-        if self.variogram_model not in self.variogram_dict.keys() and \
-                        self.variogram_model != 'custom':
-            raise ValueError("Specified variogram model '%s' "
-                             "is not supported." % variogram_model)
-        elif self.variogram_model == 'custom':
+        if (
+            self.variogram_model not in self.variogram_dict.keys()
+            and self.variogram_model != "custom"
+        ):
+            raise ValueError(
+                "Specified variogram model '%s' " "is not supported." % variogram_model
+            )
+        elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
-                raise ValueError("Must specify callable function for "
-                                 "custom variogram model.")
+                raise ValueError(
+                    "Must specify callable function for " "custom variogram model."
+                )
             else:
                 self.variogram_function = variogram_function
         else:
             self.variogram_function = self.variogram_dict[self.variogram_model]
 
-        if anisotropy_scaling_y != self.anisotropy_scaling_y or \
-           anisotropy_scaling_z != self.anisotropy_scaling_z or \
-           anisotropy_angle_x != self.anisotropy_angle_x or \
-           anisotropy_angle_y != self.anisotropy_angle_y or \
-           anisotropy_angle_z != self.anisotropy_angle_z:
+        if (
+            anisotropy_scaling_y != self.anisotropy_scaling_y
+            or anisotropy_scaling_z != self.anisotropy_scaling_z
+            or anisotropy_angle_x != self.anisotropy_angle_x
+            or anisotropy_angle_y != self.anisotropy_angle_y
+            or anisotropy_angle_z != self.anisotropy_angle_z
+        ):
             if self.verbose:
                 print("Adjusting data for anisotropy...")
             self.anisotropy_scaling_y = anisotropy_scaling_y
@@ -449,62 +512,75 @@ class UniversalKriging3D:
             self.anisotropy_angle_x = anisotropy_angle_x
             self.anisotropy_angle_y = anisotropy_angle_y
             self.anisotropy_angle_z = anisotropy_angle_z
-            self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = \
-                _adjust_for_anisotropy(np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
-                                       [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                       [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                       [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z]).T
+            self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED = _adjust_for_anisotropy(
+                np.vstack((self.X_ORIG, self.Y_ORIG, self.Z_ORIG)).T,
+                [self.XCENTER, self.YCENTER, self.ZCENTER],
+                [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+                [
+                    self.anisotropy_angle_x,
+                    self.anisotropy_angle_y,
+                    self.anisotropy_angle_z,
+                ],
+            ).T
 
         if self.verbose:
             print("Updating variogram mode...")
 
-        vp_temp = _make_variogram_parameter_list(self.variogram_model,
-                                                 variogram_parameters)
-        self.lags, self.semivariance, self.variogram_model_parameters = \
-            _initialize_variogram_model(np.vstack((self.X_ADJUSTED,
-                                                   self.Y_ADJUSTED,
-                                                   self.Z_ADJUSTED)).T,
-                                        self.VALUES, self.variogram_model,
-                                        vp_temp, self.variogram_function,
-                                        nlags, weight, 'euclidean')
+        vp_temp = _make_variogram_parameter_list(
+            self.variogram_model, variogram_parameters
+        )
+        self.lags, self.semivariance, self.variogram_model_parameters = _initialize_variogram_model(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_model,
+            vp_temp,
+            self.variogram_function,
+            nlags,
+            weight,
+            "euclidean",
+        )
 
         if self.verbose:
-            if self.variogram_model == 'linear':
-                print("Using '%s' Variogram Model" % 'linear')
+            if self.variogram_model == "linear":
+                print("Using '%s' Variogram Model" % "linear")
                 print("Slope:", self.variogram_model_parameters[0])
-                print("Nugget:", self.variogram_model_parameters[1], '\n')
-            elif self.variogram_model == 'power':
-                print("Using '%s' Variogram Model" % 'power')
+                print("Nugget:", self.variogram_model_parameters[1], "\n")
+            elif self.variogram_model == "power":
+                print("Using '%s' Variogram Model" % "power")
                 print("Scale:", self.variogram_model_parameters[0])
                 print("Exponent:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
-            elif self.variogram_model == 'custom':
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
+            elif self.variogram_model == "custom":
                 print("Using Custom Variogram Model")
             else:
                 print("Using '%s' Variogram Model" % self.variogram_model)
                 print("Partial Sill:", self.variogram_model_parameters[0])
-                print("Full Sill:", self.variogram_model_parameters[0] +
-                      self.variogram_model_parameters[2])
+                print(
+                    "Full Sill:",
+                    self.variogram_model_parameters[0]
+                    + self.variogram_model_parameters[2],
+                )
                 print("Range:", self.variogram_model_parameters[1])
-                print("Nugget:", self.variogram_model_parameters[2], '\n')
+                print("Nugget:", self.variogram_model_parameters[2], "\n")
         if self.enable_plotting:
             self.display_variogram_model()
 
         if self.verbose:
             print("Calculating statistics on variogram model fit...")
-        self.delta, self.sigma, self.epsilon = \
-            _find_statistics(np.vstack((self.X_ADJUSTED,
-                                        self.Y_ADJUSTED,
-                                        self.Z_ADJUSTED)).T,
-                             self.VALUES, self.variogram_function,
-                             self.variogram_model_parameters, 'euclidean')
+        self.delta, self.sigma, self.epsilon = _find_statistics(
+            np.vstack((self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)).T,
+            self.VALUES,
+            self.variogram_function,
+            self.variogram_model_parameters,
+            "euclidean",
+        )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
         self.cR = core.calc_cR(self.Q2, self.sigma)
         if self.verbose:
             print("Q1 =", self.Q1)
             print("Q2 =", self.Q2)
-            print("cR =", self.cR, '\n')
+            print("cR =", self.cR, "\n")
 
     def display_variogram_model(self):
         """Displays semivariogram and variogram model."""
@@ -512,9 +588,12 @@ class UniversalKriging3D:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.plot(self.lags, self.semivariance, 'r*')
-        ax.plot(self.lags,
-                self.variogram_function(self.variogram_model_parameters, self.lags), 'k-')
+        ax.plot(self.lags, self.semivariance, "r*")
+        ax.plot(
+            self.lags,
+            self.variogram_function(self.variogram_model_parameters, self.lags),
+            "k-",
+        )
         plt.show()
 
     def switch_verbose(self):
@@ -535,7 +614,7 @@ class UniversalKriging3D:
 
         fig = plt.figure()
         ax = fig.add_subplot(111)
-        ax.scatter(range(self.epsilon.size), self.epsilon, c='k', marker='*')
+        ax.scatter(range(self.epsilon.size), self.epsilon, c="k", marker="*")
         ax.axhline(y=0.0)
         plt.show()
 
@@ -557,15 +636,21 @@ class UniversalKriging3D:
     def _get_kriging_matrix(self, n, n_withdrifts):
         """Assembles the kriging matrix."""
 
-        xyz = np.concatenate((self.X_ADJUSTED[:, np.newaxis], self.Y_ADJUSTED[:, np.newaxis],
-                              self.Z_ADJUSTED[:, np.newaxis]), axis=1)
-        d = cdist(xyz, xyz, 'euclidean')
+        xyz = np.concatenate(
+            (
+                self.X_ADJUSTED[:, np.newaxis],
+                self.Y_ADJUSTED[:, np.newaxis],
+                self.Z_ADJUSTED[:, np.newaxis],
+            ),
+            axis=1,
+        )
+        d = cdist(xyz, xyz, "euclidean")
         if self.UNBIAS:
-            a = np.zeros((n_withdrifts+1, n_withdrifts+1))
+            a = np.zeros((n_withdrifts + 1, n_withdrifts + 1))
         else:
             a = np.zeros((n_withdrifts, n_withdrifts))
-        a[:n, :n] = - self.variogram_function(self.variogram_model_parameters, d)
-        np.fill_diagonal(a, 0.)
+        a[:n, :n] = -self.variogram_function(self.variogram_model_parameters, d)
+        np.fill_diagonal(a, 0.0)
 
         i = n
         if self.regional_linear_drift:
@@ -589,11 +674,13 @@ class UniversalKriging3D:
                 a[i, :n] = func(self.X_ADJUSTED, self.Y_ADJUSTED, self.Z_ADJUSTED)
                 i += 1
         if i != n_withdrifts:
-            warnings.warn("Error in creating kriging matrix. Kriging may fail.", RuntimeWarning)
+            warnings.warn(
+                "Error in creating kriging matrix. Kriging may fail.", RuntimeWarning
+            )
         if self.UNBIAS:
             a[n_withdrifts, :n] = 1.0
             a[:n, n_withdrifts] = 1.0
-            a[n:n_withdrifts + 1, n:n_withdrifts + 1] = 0.0
+            a[n : n_withdrifts + 1, n : n_withdrifts + 1] = 0.0
 
         return a
 
@@ -613,10 +700,10 @@ class UniversalKriging3D:
             zero_index = np.where(np.absolute(bd) <= self.eps)
 
         if self.UNBIAS:
-            b = np.zeros((npt, n_withdrifts+1, 1))
+            b = np.zeros((npt, n_withdrifts + 1, 1))
         else:
             b = np.zeros((npt, n_withdrifts, 1))
-        b[:, :n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+        b[:, :n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
         if zero_value:
             b[zero_index[0], zero_index[1], 0] = 0.0
 
@@ -637,20 +724,31 @@ class UniversalKriging3D:
                 b[:, i, 0] = func(xyz[:, 2], xyz[:, 1], xyz[:, 0])
                 i += 1
         if i != n_withdrifts:
-            warnings.warn("Error in setting up kriging system. "
-                          "Kriging may fail.", RuntimeWarning)
+            warnings.warn(
+                "Error in setting up kriging system. " "Kriging may fail.",
+                RuntimeWarning,
+            )
         if self.UNBIAS:
             b[:, n_withdrifts, 0] = 1.0
 
         if (~mask).any():
-            mask_b = np.repeat(mask[:, np.newaxis, np.newaxis],
-                               n_withdrifts+1, axis=1)
+            mask_b = np.repeat(
+                mask[:, np.newaxis, np.newaxis], n_withdrifts + 1, axis=1
+            )
             b = np.ma.array(b, mask=mask_b)
 
         if self.UNBIAS:
-            x = np.dot(a_inv, b.reshape((npt, n_withdrifts+1)).T).reshape((1, n_withdrifts+1, npt)).T
+            x = (
+                np.dot(a_inv, b.reshape((npt, n_withdrifts + 1)).T)
+                .reshape((1, n_withdrifts + 1, npt))
+                .T
+            )
         else:
-            x = np.dot(a_inv, b.reshape((npt, n_withdrifts)).T).reshape((1, n_withdrifts, npt)).T
+            x = (
+                np.dot(a_inv, b.reshape((npt, n_withdrifts)).T)
+                .reshape((1, n_withdrifts, npt))
+                .T
+            )
         kvalues = np.sum(x[:, :n, 0] * self.VALUES, axis=1)
         sigmasq = np.sum(x[:, :, 0] * -b[:, :, 0], axis=1)
 
@@ -667,8 +765,10 @@ class UniversalKriging3D:
 
         a_inv = scipy.linalg.inv(a)
 
-        for j in np.nonzero(~mask)[0]:   # Note that this is the same thing as range(npt) if mask is not defined,
-            bd = bd_all[j]               # otherwise it takes the non-masked elements.
+        for j in np.nonzero(~mask)[
+            0
+        ]:  # Note that this is the same thing as range(npt) if mask is not defined,
+            bd = bd_all[j]  # otherwise it takes the non-masked elements.
             if np.any(np.absolute(bd) <= self.eps):
                 zero_value = True
                 zero_index = np.where(np.absolute(bd) <= self.eps)
@@ -677,10 +777,10 @@ class UniversalKriging3D:
                 zero_index = None
 
             if self.UNBIAS:
-                b = np.zeros((n_withdrifts+1, 1))
+                b = np.zeros((n_withdrifts + 1, 1))
             else:
                 b = np.zeros((n_withdrifts, 1))
-            b[:n, 0] = - self.variogram_function(self.variogram_model_parameters, bd)
+            b[:n, 0] = -self.variogram_function(self.variogram_model_parameters, bd)
             if zero_value:
                 b[zero_index[0], 0] = 0.0
 
@@ -701,8 +801,10 @@ class UniversalKriging3D:
                     b[i, 0] = func(xyz[j, 2], xyz[j, 1], xyz[j, 0])
                     i += 1
             if i != n_withdrifts:
-                warnings.warn("Error in setting up kriging system. "
-                              "Kriging may fail.", RuntimeWarning)
+                warnings.warn(
+                    "Error in setting up kriging system. " "Kriging may fail.",
+                    RuntimeWarning,
+                )
             if self.UNBIAS:
                 b[n_withdrifts, 0] = 1.0
 
@@ -712,8 +814,16 @@ class UniversalKriging3D:
 
         return kvalues, sigmasq
 
-    def execute(self, style, xpoints, ypoints, zpoints, mask=None,
-                backend='vectorized', specified_drift_arrays=None):
+    def execute(
+        self,
+        style,
+        xpoints,
+        ypoints,
+        zpoints,
+        mask=None,
+        backend="vectorized",
+        specified_drift_arrays=None,
+    ):
         """Calculates a kriged grid and the associated variance.
 
         This is now the method that performs the main kriging calculation.
@@ -805,9 +915,8 @@ class UniversalKriging3D:
         if self.verbose:
             print("Executing Ordinary Kriging...\n")
 
-        if style != 'grid' and style != 'masked' and style != 'points':
-            raise ValueError("style argument must be 'grid', 'points', "
-                             "or 'masked'")
+        if style != "grid" and style != "masked" and style != "points":
+            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
 
         xpts = np.atleast_1d(np.squeeze(np.array(xpoints, copy=True)))
         ypts = np.atleast_1d(np.squeeze(np.array(ypoints, copy=True)))
@@ -825,111 +934,152 @@ class UniversalKriging3D:
         nz = zpts.size
         a = self._get_kriging_matrix(n, n_withdrifts)
 
-        if style in ['grid', 'masked']:
-            if style == 'masked':
+        if style in ["grid", "masked"]:
+            if style == "masked":
                 if mask is None:
-                    raise IOError("Must specify boolean masking array "
-                                  "when style is 'masked'.")
+                    raise IOError(
+                        "Must specify boolean masking array " "when style is 'masked'."
+                    )
                 if mask.ndim != 3:
                     raise ValueError("Mask is not three-dimensional.")
                 if mask.shape[0] != nz or mask.shape[1] != ny or mask.shape[2] != nx:
-                    if mask.shape[0] == nx and mask.shape[2] == nz and mask.shape[1] == ny:
+                    if (
+                        mask.shape[0] == nx
+                        and mask.shape[2] == nz
+                        and mask.shape[1] == ny
+                    ):
                         mask = mask.swapaxes(0, 2)
                     else:
-                        raise ValueError("Mask dimensions do not match "
-                                         "specified grid dimensions.")
+                        raise ValueError(
+                            "Mask dimensions do not match " "specified grid dimensions."
+                        )
                 mask = mask.flatten()
             npt = nz * ny * nx
-            grid_z, grid_y, grid_x = np.meshgrid(zpts, ypts, xpts, indexing='ij')
+            grid_z, grid_y, grid_x = np.meshgrid(zpts, ypts, xpts, indexing="ij")
             xpts = grid_x.flatten()
             ypts = grid_y.flatten()
             zpts = grid_z.flatten()
-        elif style == 'points':
+        elif style == "points":
             if xpts.size != ypts.size and ypts.size != zpts.size:
-                raise ValueError("xpoints and ypoints must have same "
-                                 "dimensions when treated as listing "
-                                 "discrete points.")
+                raise ValueError(
+                    "xpoints and ypoints must have same "
+                    "dimensions when treated as listing "
+                    "discrete points."
+                )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', 'points', "
-                             "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
 
         if specified_drift_arrays is None:
             specified_drift_arrays = []
         spec_drift_grids = []
         if self.specified_drift:
             if len(specified_drift_arrays) == 0:
-                raise ValueError("Must provide drift values for kriging "
-                                 "points when using 'specified' drift "
-                                 "capability.")
+                raise ValueError(
+                    "Must provide drift values for kriging "
+                    "points when using 'specified' drift "
+                    "capability."
+                )
             if type(specified_drift_arrays) is not list:
-                raise TypeError("Arrays for specified drift terms must "
-                                "be encapsulated in a list.")
+                raise TypeError(
+                    "Arrays for specified drift terms must "
+                    "be encapsulated in a list."
+                )
             for spec in specified_drift_arrays:
-                if style in ['grid', 'masked']:
+                if style in ["grid", "masked"]:
                     if spec.ndim < 3:
-                        raise ValueError("Dimensions of drift values array do "
-                                         "not match specified grid dimensions.")
-                    elif spec.shape[0] != nz or spec.shape[1] != ny or spec.shape[2] != nx:
-                        if spec.shape[0] == nx and spec.shape[2] == nz and spec.shape[1] == ny:
+                        raise ValueError(
+                            "Dimensions of drift values array do "
+                            "not match specified grid dimensions."
+                        )
+                    elif (
+                        spec.shape[0] != nz
+                        or spec.shape[1] != ny
+                        or spec.shape[2] != nx
+                    ):
+                        if (
+                            spec.shape[0] == nx
+                            and spec.shape[2] == nz
+                            and spec.shape[1] == ny
+                        ):
                             spec_drift_grids.append(np.squeeze(spec.swapaxes(0, 2)))
                         else:
-                            raise ValueError("Dimensions of drift values array "
-                                             "do not match specified grid "
-                                             "dimensions.")
+                            raise ValueError(
+                                "Dimensions of drift values array "
+                                "do not match specified grid "
+                                "dimensions."
+                            )
                     else:
                         spec_drift_grids.append(np.squeeze(spec))
-                elif style == 'points':
+                elif style == "points":
                     if spec.ndim != 1:
-                        raise ValueError("Dimensions of drift values array do "
-                                         "not match specified grid dimensions.")
+                        raise ValueError(
+                            "Dimensions of drift values array do "
+                            "not match specified grid dimensions."
+                        )
                     elif spec.shape[0] != xpts.size:
-                        raise ValueError("Number of supplied drift values in "
-                                         "array do not match specified number "
-                                         "of kriging points.")
+                        raise ValueError(
+                            "Number of supplied drift values in "
+                            "array do not match specified number "
+                            "of kriging points."
+                        )
                     else:
                         spec_drift_grids.append(np.squeeze(spec))
             if len(spec_drift_grids) != len(self.specified_drift_data_arrays):
-                raise ValueError("Inconsistent number of specified "
-                                 "drift terms supplied.")
+                raise ValueError(
+                    "Inconsistent number of specified " "drift terms supplied."
+                )
         else:
             if len(specified_drift_arrays) != 0:
-                warnings.warn("Provided specified drift values, but "
-                              "'specified' drift was not initialized during "
-                              "instantiation of UniversalKriging3D class.",
-                              RuntimeWarning)
+                warnings.warn(
+                    "Provided specified drift values, but "
+                    "'specified' drift was not initialized during "
+                    "instantiation of UniversalKriging3D class.",
+                    RuntimeWarning,
+                )
 
-        xpts, ypts, zpts = _adjust_for_anisotropy(np.vstack((xpts, ypts, zpts)).T,
-                                                  [self.XCENTER, self.YCENTER, self.ZCENTER],
-                                                  [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
-                                                  [self.anisotropy_angle_x, self.anisotropy_angle_y,
-                                                  self.anisotropy_angle_z]).T
+        xpts, ypts, zpts = _adjust_for_anisotropy(
+            np.vstack((xpts, ypts, zpts)).T,
+            [self.XCENTER, self.YCENTER, self.ZCENTER],
+            [self.anisotropy_scaling_y, self.anisotropy_scaling_z],
+            [self.anisotropy_angle_x, self.anisotropy_angle_y, self.anisotropy_angle_z],
+        ).T
 
-        if style != 'masked':
-            mask = np.zeros(npt, dtype='bool')
+        if style != "masked":
+            mask = np.zeros(npt, dtype="bool")
 
-        xyz_points = np.concatenate((zpts[:, np.newaxis], ypts[:, np.newaxis],
-                                     xpts[:, np.newaxis]), axis=1)
-        xyz_data = np.concatenate((self.Z_ADJUSTED[:, np.newaxis],
-                                   self.Y_ADJUSTED[:, np.newaxis],
-                                   self.X_ADJUSTED[:, np.newaxis]), axis=1)
-        bd = cdist(xyz_points, xyz_data, 'euclidean')
+        xyz_points = np.concatenate(
+            (zpts[:, np.newaxis], ypts[:, np.newaxis], xpts[:, np.newaxis]), axis=1
+        )
+        xyz_data = np.concatenate(
+            (
+                self.Z_ADJUSTED[:, np.newaxis],
+                self.Y_ADJUSTED[:, np.newaxis],
+                self.X_ADJUSTED[:, np.newaxis],
+            ),
+            axis=1,
+        )
+        bd = cdist(xyz_points, xyz_data, "euclidean")
 
-        if backend == 'vectorized':
-            kvalues, sigmasq = self._exec_vector(a, bd, xyz_points, mask,
-                                                 n_withdrifts, spec_drift_grids)
-        elif backend == 'loop':
-            kvalues, sigmasq = self._exec_loop(a, bd, xyz_points, mask,
-                                               n_withdrifts, spec_drift_grids)
+        if backend == "vectorized":
+            kvalues, sigmasq = self._exec_vector(
+                a, bd, xyz_points, mask, n_withdrifts, spec_drift_grids
+            )
+        elif backend == "loop":
+            kvalues, sigmasq = self._exec_loop(
+                a, bd, xyz_points, mask, n_withdrifts, spec_drift_grids
+            )
         else:
-            raise ValueError('Specified backend {} is not supported for '
-                             '3D ordinary kriging.'.format(backend))
+            raise ValueError(
+                "Specified backend {} is not supported for "
+                "3D ordinary kriging.".format(backend)
+            )
 
-        if style == 'masked':
+        if style == "masked":
             kvalues = np.ma.array(kvalues, mask=mask)
             sigmasq = np.ma.array(sigmasq, mask=mask)
 
-        if style in ['masked', 'grid']:
+        if style in ["masked", "grid"]:
             kvalues = kvalues.reshape((nz, ny, nx))
             sigmasq = sigmasq.reshape((nz, ny, nx))
 

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -238,12 +238,12 @@ class UniversalKriging3D:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -486,12 +486,12 @@ class UniversalKriging3D:
             and self.variogram_model != "custom"
         ):
             raise ValueError(
-                "Specified variogram model '%s' " "is not supported." % variogram_model
+                "Specified variogram model '%s' is not supported." % variogram_model
             )
         elif self.variogram_model == "custom":
             if variogram_function is None or not callable(variogram_function):
                 raise ValueError(
-                    "Must specify callable function for " "custom variogram model."
+                    "Must specify callable function for custom variogram model."
                 )
             else:
                 self.variogram_function = variogram_function
@@ -725,7 +725,7 @@ class UniversalKriging3D:
                 i += 1
         if i != n_withdrifts:
             warnings.warn(
-                "Error in setting up kriging system. " "Kriging may fail.",
+                "Error in setting up kriging system. Kriging may fail.",
                 RuntimeWarning,
             )
         if self.UNBIAS:
@@ -802,7 +802,7 @@ class UniversalKriging3D:
                     i += 1
             if i != n_withdrifts:
                 warnings.warn(
-                    "Error in setting up kriging system. " "Kriging may fail.",
+                    "Error in setting up kriging system. Kriging may fail.",
                     RuntimeWarning,
                 )
             if self.UNBIAS:
@@ -916,7 +916,7 @@ class UniversalKriging3D:
             print("Executing Ordinary Kriging...\n")
 
         if style != "grid" and style != "masked" and style != "points":
-            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         xpts = np.atleast_1d(np.squeeze(np.array(xpoints, copy=True)))
         ypts = np.atleast_1d(np.squeeze(np.array(ypoints, copy=True)))
@@ -938,7 +938,7 @@ class UniversalKriging3D:
             if style == "masked":
                 if mask is None:
                     raise IOError(
-                        "Must specify boolean masking array " "when style is 'masked'."
+                        "Must specify boolean masking array when style is 'masked'."
                     )
                 if mask.ndim != 3:
                     raise ValueError("Mask is not three-dimensional.")
@@ -951,7 +951,7 @@ class UniversalKriging3D:
                         mask = mask.swapaxes(0, 2)
                     else:
                         raise ValueError(
-                            "Mask dimensions do not match " "specified grid dimensions."
+                            "Mask dimensions do not match specified grid dimensions."
                         )
                 mask = mask.flatten()
             npt = nz * ny * nx
@@ -968,7 +968,7 @@ class UniversalKriging3D:
                 )
             npt = nx
         else:
-            raise ValueError("style argument must be 'grid', 'points', " "or 'masked'")
+            raise ValueError("style argument must be 'grid', 'points', or 'masked'")
 
         if specified_drift_arrays is None:
             specified_drift_arrays = []
@@ -1027,7 +1027,7 @@ class UniversalKriging3D:
                         spec_drift_grids.append(np.squeeze(spec))
             if len(spec_drift_grids) != len(self.specified_drift_data_arrays):
                 raise ValueError(
-                    "Inconsistent number of specified " "drift terms supplied."
+                    "Inconsistent number of specified drift terms supplied."
                 )
         else:
             if len(specified_drift_arrays) != 0:

--- a/pykrige/variogram_models.py
+++ b/pykrige/variogram_models.py
@@ -42,7 +42,7 @@ def gaussian_variogram_model(m, d):
     psill = float(m[0])
     range_ = float(m[1])
     nugget = float(m[2])
-    return psill * (1.0 - np.exp(-d ** 2.0 / (range_ * 4.0 / 7.0) ** 2.0)) + nugget
+    return psill * (1.0 - np.exp(-(d ** 2.0) / (range_ * 4.0 / 7.0) ** 2.0)) + nugget
 
 
 def exponential_variogram_model(m, d):

--- a/pykrige/variogram_models.py
+++ b/pykrige/variogram_models.py
@@ -17,7 +17,7 @@ References
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
 
-Copyright (c) 2015-2018, PyKrige Developers
+Copyright (c) 2015-2020, PyKrige Developers
 """
 import numpy as np
 
@@ -34,7 +34,7 @@ def power_variogram_model(m, d):
     scale = float(m[0])
     exponent = float(m[1])
     nugget = float(m[2])
-    return scale * d**exponent + nugget
+    return scale * d ** exponent + nugget
 
 
 def gaussian_variogram_model(m, d):
@@ -42,7 +42,7 @@ def gaussian_variogram_model(m, d):
     psill = float(m[0])
     range_ = float(m[1])
     nugget = float(m[2])
-    return psill * (1. - np.exp(-d**2./(range_*4./7.)**2.)) + nugget
+    return psill * (1.0 - np.exp(-d ** 2.0 / (range_ * 4.0 / 7.0) ** 2.0)) + nugget
 
 
 def exponential_variogram_model(m, d):
@@ -50,7 +50,7 @@ def exponential_variogram_model(m, d):
     psill = float(m[0])
     range_ = float(m[1])
     nugget = float(m[2])
-    return psill * (1. - np.exp(-d/(range_/3.))) + nugget
+    return psill * (1.0 - np.exp(-d / (range_ / 3.0))) + nugget
 
 
 def spherical_variogram_model(m, d):
@@ -58,8 +58,16 @@ def spherical_variogram_model(m, d):
     psill = float(m[0])
     range_ = float(m[1])
     nugget = float(m[2])
-    return np.piecewise(d, [d <= range_, d > range_],
-                        [lambda x: psill * ((3.*x)/(2.*range_) - (x**3.)/(2.*range_**3.)) + nugget, psill + nugget])
+    return np.piecewise(
+        d,
+        [d <= range_, d > range_],
+        [
+            lambda x: psill
+            * ((3.0 * x) / (2.0 * range_) - (x ** 3.0) / (2.0 * range_ ** 3.0))
+            + nugget,
+            psill + nugget,
+        ],
+    )
 
 
 def hole_effect_variogram_model(m, d):
@@ -67,4 +75,7 @@ def hole_effect_variogram_model(m, d):
     psill = float(m[0])
     range_ = float(m[1])
     nugget = float(m[2])
-    return psill * (1. - (1.-d/(range_/3.)) * np.exp(-d/(range_/3.))) + nugget
+    return (
+        psill * (1.0 - (1.0 - d / (range_ / 3.0)) * np.exp(-d / (range_ / 3.0)))
+        + nugget
+    )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,5 @@
 pytest-cov>=2.8.0
 pytest>=5.3.0
+coveralls>=1.9.0
 scikit-learn>=0.18
+gstools>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,7 @@ with open(os.path.join(HERE, "requirements_setup.txt"), encoding="utf-8") as f:
     REQ_SETUP = f.read().splitlines()
 with open(os.path.join(HERE, "requirements_test.txt"), encoding="utf-8") as f:
     REQ_TEST = f.read().splitlines()
-with open(
-    os.path.join(HERE, "docs", "requirements_doc.txt"), encoding="utf-8"
-) as f:
+with open(os.path.join(HERE, "docs", "requirements_doc.txt"), encoding="utf-8") as f:
     REQ_DOC = f.read().splitlines()
 
 REQ_DEV = REQ_SETUP + REQ_TEST + REQ_DOC

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,6 @@ def test_krige():
             Krige(),
             param_dict,
             n_jobs=-1,
-            iid=False,
             pre_dispatch="2*n_jobs",
             verbose=False,
             cv=5,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,9 +8,8 @@ from pykrige.compat import GridSearchCV
 
 
 def _method_and_vergiogram():
-    method = ['ordinary', 'universal', 'ordinary3d', 'universal3d']
-    variogram_model = ['linear', 'power', 'gaussian', 'spherical',
-                       'exponential']
+    method = ["ordinary", "universal", "ordinary3d", "universal3d"]
+    variogram_model = ["linear", "power", "gaussian", "spherical", "exponential"]
     return product(method, variogram_model)
 
 
@@ -21,25 +20,26 @@ def test_krige():
     y = 5 * np.random.rand(20)
 
     for m, v in _method_and_vergiogram():
-        param_dict = {'method': [m], 'variogram_model': [v]}
+        param_dict = {"method": [m], "variogram_model": [v]}
 
-        estimator = GridSearchCV(Krige(),
-                                 param_dict,
-                                 n_jobs=-1,
-                                 iid=False,
-                                 pre_dispatch='2*n_jobs',
-                                 verbose=False,
-                                 cv=5,
-                                 )
+        estimator = GridSearchCV(
+            Krige(),
+            param_dict,
+            n_jobs=-1,
+            iid=False,
+            pre_dispatch="2*n_jobs",
+            verbose=False,
+            cv=5,
+        )
         # run the gridsearch
-        if m in ['ordinary', 'universal']:
+        if m in ["ordinary", "universal"]:
             estimator.fit(X=X[:, :2], y=y)
         else:
             estimator.fit(X=X, y=y)
-        if hasattr(estimator, 'best_score_'):
+        if hasattr(estimator, "best_score_"):
             if m in threed_krige:
                 assert estimator.best_score_ > -10.0
             else:
                 assert estimator.best_score_ > -3.0
-        if hasattr(estimator, 'cv_results_'):
-            assert estimator.cv_results_['mean_train_score'] > 0
+        if hasattr(estimator, "cv_results_"):
+            assert estimator.cv_results_["mean_train_score"] > 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,34 +21,39 @@ from pykrige.uk3d import UniversalKriging3D
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-allclose_pars = {'rtol': 1e-05, 'atol': 1e-08}
+allclose_pars = {"rtol": 1e-05, "atol": 1e-08}
 
 
 @pytest.fixture
 def validation_ref():
 
-    data = np.genfromtxt(os.path.join(BASE_DIR, 'test_data/test_data.txt'))
-    ok_test_answer, ok_test_gridx, ok_test_gridy, \
-        cellsize, no_data = kt.read_asc_grid(
-            os.path.join(BASE_DIR, 'test_data/test1_answer.asc'),
-            footer=2)
-    uk_test_answer, uk_test_gridx, uk_test_gridy, \
-        cellsize, no_data = kt.read_asc_grid(
-            os.path.join(BASE_DIR, 'test_data/test2_answer.asc'),
-            footer=2)
+    data = np.genfromtxt(os.path.join(BASE_DIR, "test_data/test_data.txt"))
+    ok_test_answer, ok_test_gridx, ok_test_gridy, cellsize, no_data = kt.read_asc_grid(
+        os.path.join(BASE_DIR, "test_data/test1_answer.asc"), footer=2
+    )
+    uk_test_answer, uk_test_gridx, uk_test_gridy, cellsize, no_data = kt.read_asc_grid(
+        os.path.join(BASE_DIR, "test_data/test2_answer.asc"), footer=2
+    )
 
-    return (data, (ok_test_answer, ok_test_gridx, ok_test_gridy),
-            (uk_test_answer, uk_test_gridx, uk_test_gridy))
+    return (
+        data,
+        (ok_test_answer, ok_test_gridx, ok_test_gridy),
+        (uk_test_answer, uk_test_gridx, uk_test_gridy),
+    )
 
 
 @pytest.fixture
 def sample_data_2d():
 
-    data = np.array([[0.3, 1.2, 0.47],
-                     [1.9, 0.6, 0.56],
-                     [1.1, 3.2, 0.74],
-                     [3.3, 4.4, 1.47],
-                     [4.7, 3.8, 1.74]])
+    data = np.array(
+        [
+            [0.3, 1.2, 0.47],
+            [1.9, 0.6, 0.56],
+            [1.1, 3.2, 0.74],
+            [3.3, 4.4, 1.47],
+            [4.7, 3.8, 1.74],
+        ]
+    )
     gridx = np.arange(0.0, 6.0, 1.0)
     gridx_2 = np.arange(0.0, 5.5, 0.5)
     gridy = np.arange(0.0, 5.5, 0.5)
@@ -59,127 +64,125 @@ def sample_data_2d():
 
 @pytest.fixture
 def sample_data_3d():
-    data = np.array([[0.1, 0.1, 0.3, 0.9],
-                     [0.2, 0.1, 0.4, 0.8],
-                     [0.1, 0.3, 0.1, 0.9],
-                     [0.5, 0.4, 0.4, 0.5],
-                     [0.3, 0.3, 0.2, 0.7]])
+    data = np.array(
+        [
+            [0.1, 0.1, 0.3, 0.9],
+            [0.2, 0.1, 0.4, 0.8],
+            [0.1, 0.3, 0.1, 0.9],
+            [0.5, 0.4, 0.4, 0.5],
+            [0.3, 0.3, 0.2, 0.7],
+        ]
+    )
     gridx = np.arange(0.0, 0.6, 0.05)
     gridy = np.arange(0.0, 0.6, 0.01)
     gridz = np.arange(0.0, 0.6, 0.1)
-    zi, yi, xi = np.meshgrid(gridz, gridy, gridx, indexing='ij')
+    zi, yi, xi = np.meshgrid(gridz, gridy, gridx, indexing="ij")
     mask = np.array((xi == yi) & (yi == zi))
     return data, (gridx, gridy, gridz), mask
 
 
 def test_core_adjust_for_anisotropy():
 
-    X = np.array([[1.0, 0.0, -1.0, 0.0],
-                  [0.0, 1.0, 0.0, -1.0]]).T
+    X = np.array([[1.0, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, -1.0]]).T
     X_adj = core._adjust_for_anisotropy(X, [0.0, 0.0], [2.0], [90.0])
-    assert_allclose(X_adj[:, 0],
-                    np.array([0.0, 1.0, 0.0, -1.0]), **allclose_pars)
-    assert_allclose(X_adj[:, 1],
-                    np.array([-2.0, 0.0, 2.0, 0.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 0], np.array([0.0, 1.0, 0.0, -1.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 1], np.array([-2.0, 0.0, 2.0, 0.0]), **allclose_pars)
 
 
 def test_core_adjust_for_anisotropy_3d():
 
     # this is a bad examples, as the X matrix is symmetric
     # and insensitive to transpositions
-    X = np.array([[1.0, 0.0, 0.0],
-                  [0.0, 1.0, 0.0],
-                  [0.0, 0.0, 1.0]]).T
-    X_adj = core._adjust_for_anisotropy(X, [0., 0., 0.], [2., 2.],
-                                        [90., 0., 0.])
-    assert_allclose(X_adj[:, 0], np.array([1., 0., 0.]), **allclose_pars)
-    assert_allclose(X_adj[:, 1], np.array([0., 0., 2.]), **allclose_pars)
-    assert_allclose(X_adj[:, 2], np.array([0., -2., 0.]), **allclose_pars)
-    X_adj = core._adjust_for_anisotropy(X, [0., 0., 0.], [2., 2.],
-                                        [0., 90., 0.])
-    assert_allclose(X_adj[:, 0], np.array([0., 0., -1.]), **allclose_pars)
-    assert_allclose(X_adj[:, 1], np.array([0., 2., 0.]), **allclose_pars)
-    assert_allclose(X_adj[:, 2], np.array([2., 0., 0.]), **allclose_pars)
-    X_adj = core._adjust_for_anisotropy(X, [0., 0., 0.], [2., 2.],
-                                        [0., 0., 90.])
-    assert_allclose(X_adj[:, 0], np.array([0., 1., 0.]), **allclose_pars)
-    assert_allclose(X_adj[:, 1], np.array([-2., 0., 0.]), **allclose_pars)
-    assert_allclose(X_adj[:, 2], np.array([0., 0., 2.]), **allclose_pars)
+    X = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]).T
+    X_adj = core._adjust_for_anisotropy(
+        X, [0.0, 0.0, 0.0], [2.0, 2.0], [90.0, 0.0, 0.0]
+    )
+    assert_allclose(X_adj[:, 0], np.array([1.0, 0.0, 0.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 1], np.array([0.0, 0.0, 2.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 2], np.array([0.0, -2.0, 0.0]), **allclose_pars)
+    X_adj = core._adjust_for_anisotropy(
+        X, [0.0, 0.0, 0.0], [2.0, 2.0], [0.0, 90.0, 0.0]
+    )
+    assert_allclose(X_adj[:, 0], np.array([0.0, 0.0, -1.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 1], np.array([0.0, 2.0, 0.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 2], np.array([2.0, 0.0, 0.0]), **allclose_pars)
+    X_adj = core._adjust_for_anisotropy(
+        X, [0.0, 0.0, 0.0], [2.0, 2.0], [0.0, 0.0, 90.0]
+    )
+    assert_allclose(X_adj[:, 0], np.array([0.0, 1.0, 0.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 1], np.array([-2.0, 0.0, 0.0]), **allclose_pars)
+    assert_allclose(X_adj[:, 2], np.array([0.0, 0.0, 2.0]), **allclose_pars)
 
 
 def test_core_make_variogram_parameter_list():
 
     # test of first case - variogram_model_parameters is None
     # function should return None unaffected
-    result = core._make_variogram_parameter_list('linear', None)
+    result = core._make_variogram_parameter_list("linear", None)
     assert result is None
 
     # tests for second case - variogram_model_parameters is dict
     with pytest.raises(KeyError):
-        core._make_variogram_parameter_list(
-                      'linear', {'tacos': 1., 'burritos': 2.})
-    result = core._make_variogram_parameter_list('linear', {'slope': 1.,
-                                                            'nugget': 0.})
-    assert result == [1., 0.]
+        core._make_variogram_parameter_list("linear", {"tacos": 1.0, "burritos": 2.0})
+    result = core._make_variogram_parameter_list(
+        "linear", {"slope": 1.0, "nugget": 0.0}
+    )
+    assert result == [1.0, 0.0]
 
     with pytest.raises(KeyError):
-        core._make_variogram_parameter_list(
-                      'power', {'frijoles': 1.})
-    result = core._make_variogram_parameter_list('power', {'scale': 2.,
-                                                           'exponent': 1.,
-                                                           'nugget': 0.})
-    assert result == [2., 1., 0.]
+        core._make_variogram_parameter_list("power", {"frijoles": 1.0})
+    result = core._make_variogram_parameter_list(
+        "power", {"scale": 2.0, "exponent": 1.0, "nugget": 0.0}
+    )
+    assert result == [2.0, 1.0, 0.0]
 
     with pytest.raises(KeyError):
-        core._make_variogram_parameter_list(
-                      'exponential', {'tacos': 1.})
+        core._make_variogram_parameter_list("exponential", {"tacos": 1.0})
     with pytest.raises(KeyError):
-            core._make_variogram_parameter_list(
-                      'exponential', {'range': 1., 'nugget': 1.})
-    result = core._make_variogram_parameter_list('exponential',
-                                                 {'sill': 5., 'range': 2.,
-                                                  'nugget': 1.})
-    assert result == [4., 2., 1.]
-    result = core._make_variogram_parameter_list('exponential',
-                                                 {'psill': 4., 'range': 2.,
-                                                  'nugget': 1.})
-    assert result == [4., 2., 1.]
+        core._make_variogram_parameter_list(
+            "exponential", {"range": 1.0, "nugget": 1.0}
+        )
+    result = core._make_variogram_parameter_list(
+        "exponential", {"sill": 5.0, "range": 2.0, "nugget": 1.0}
+    )
+    assert result == [4.0, 2.0, 1.0]
+    result = core._make_variogram_parameter_list(
+        "exponential", {"psill": 4.0, "range": 2.0, "nugget": 1.0}
+    )
+    assert result == [4.0, 2.0, 1.0]
 
     with pytest.raises(TypeError):
-        core._make_variogram_parameter_list('custom', {'junk': 1.})
+        core._make_variogram_parameter_list("custom", {"junk": 1.0})
     with pytest.raises(ValueError):
-        core._make_variogram_parameter_list('blarg', {'junk': 1.})
+        core._make_variogram_parameter_list("blarg", {"junk": 1.0})
 
     # tests for third case - variogram_model_parameters is list
     with pytest.raises(ValueError):
-        core._make_variogram_parameter_list(
-                      'linear', [1., 2., 3.])
-    result = core._make_variogram_parameter_list('linear', [1., 2.])
-    assert result == [1., 2.]
+        core._make_variogram_parameter_list("linear", [1.0, 2.0, 3.0])
+    result = core._make_variogram_parameter_list("linear", [1.0, 2.0])
+    assert result == [1.0, 2.0]
 
     with pytest.raises(ValueError):
-        core._make_variogram_parameter_list('power', [1., 2.])
+        core._make_variogram_parameter_list("power", [1.0, 2.0])
 
-    result = core._make_variogram_parameter_list('power', [1., 2., 3.])
-    assert result == [1., 2., 3.]
-
-    with pytest.raises(ValueError):
-        core._make_variogram_parameter_list(
-                      'exponential', [1., 2., 3., 4.])
-    result = core._make_variogram_parameter_list('exponential',
-                                                 [5., 2., 1.])
-    assert result == [4., 2., 1.]
-
-    result = core._make_variogram_parameter_list('custom', [1., 2., 3.])
-    assert result == [1., 2., 3]
+    result = core._make_variogram_parameter_list("power", [1.0, 2.0, 3.0])
+    assert result == [1.0, 2.0, 3.0]
 
     with pytest.raises(ValueError):
-        core._make_variogram_parameter_list('junk', [1., 1., 1.])
+        core._make_variogram_parameter_list("exponential", [1.0, 2.0, 3.0, 4.0])
+    result = core._make_variogram_parameter_list("exponential", [5.0, 2.0, 1.0])
+    assert result == [4.0, 2.0, 1.0]
+
+    result = core._make_variogram_parameter_list("custom", [1.0, 2.0, 3.0])
+    assert result == [1.0, 2.0, 3]
+
+    with pytest.raises(ValueError):
+        core._make_variogram_parameter_list("junk", [1.0, 1.0, 1.0])
 
     # test for last case - make sure function handles incorrect
     # variogram_model_parameters type appropriately
     with pytest.raises(TypeError):
-        core._make_variogram_parameter_list('linear', 'tacos')
+        core._make_variogram_parameter_list("linear", "tacos")
 
 
 def test_core_initialize_variogram_model(validation_ref):
@@ -192,30 +195,47 @@ def test_core_initialize_variogram_model(validation_ref):
     # core._make_variogram_parameter_list
     with pytest.raises(ValueError):
         core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1])).T,
-                      data[:, 2], 'linear', [0.0], 'linear',
-                      6, False, 'euclidean')
+            np.vstack((data[:, 0], data[:, 1])).T,
+            data[:, 2],
+            "linear",
+            [0.0],
+            "linear",
+            6,
+            False,
+            "euclidean",
+        )
     with pytest.raises(ValueError):
-            core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1])).T,
-                      data[:, 2], 'spherical', [0.0],
-                      'spherical', 6, False, 'euclidean')
+        core._initialize_variogram_model(
+            np.vstack((data[:, 0], data[:, 1])).T,
+            data[:, 2],
+            "spherical",
+            [0.0],
+            "spherical",
+            6,
+            False,
+            "euclidean",
+        )
 
     # core._initialize_variogram_model does also check coordinate type,
     # this is NOT redundant
     with pytest.raises(ValueError):
         core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1])).T,
-                      data[:, 2], 'spherical', [0.0, 0.0, 0.0],
-                      'spherical', 6, False, 'tacos')
+            np.vstack((data[:, 0], data[:, 1])).T,
+            data[:, 2],
+            "spherical",
+            [0.0, 0.0, 0.0],
+            "spherical",
+            6,
+            False,
+            "tacos",
+        )
 
-    x = np.array([1.0 + n/np.sqrt(2) for n in range(4)])
-    y = np.array([1.0 + n/np.sqrt(2) for n in range(4)])
+    x = np.array([1.0 + n / np.sqrt(2) for n in range(4)])
+    y = np.array([1.0 + n / np.sqrt(2) for n in range(4)])
     z = np.arange(1.0, 5.0, 1.0)
-    lags, semivariance, variogram_model_parameters = \
-        core._initialize_variogram_model(np.vstack((x, y)).T, z,
-                                         'linear', [0.0, 0.0],
-                                         'linear', 6, False, 'euclidean')
+    lags, semivariance, variogram_model_parameters = core._initialize_variogram_model(
+        np.vstack((x, y)).T, z, "linear", [0.0, 0.0], "linear", 6, False, "euclidean"
+    )
 
     assert_allclose(lags, np.array([1.0, 2.0, 3.0]))
     assert_allclose(semivariance, np.array([0.5, 2.0, 4.5]))
@@ -231,98 +251,160 @@ def test_core_initialize_variogram_model_3d(sample_data_3d):
     # core._make_variogram_parameter_list
     with pytest.raises(ValueError):
         core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
-                      data[:, 3], 'linear', [0.0], 'linear',
-                      6, False, 'euclidean')
+            np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+            data[:, 3],
+            "linear",
+            [0.0],
+            "linear",
+            6,
+            False,
+            "euclidean",
+        )
 
     with pytest.raises(ValueError):
-            core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
-                      data[:, 3], 'spherical', [0.0],
-                      'spherical', 6, False, 'euclidean')
-
-    with pytest.raises(ValueError):
-                core._initialize_variogram_model(
-                      np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
-                      data[:, 3], 'linear', [0.0, 0.0],
-                      'linear', 6, False, 'geographic')
-
-    lags, semivariance, variogram_model_parameters = \
         core._initialize_variogram_model(
-            np.vstack((np.array([1., 2., 3., 4.]),
-                       np.array([1., 2., 3., 4.]),
-                       np.array([1., 2., 3., 4.]))).T,
-            np.array([1., 2., 3., 4.]), 'linear', [0.0, 0.0], 'linear', 3,
-            False, 'euclidean')
-    assert_allclose(lags, np.array([np.sqrt(3.), 2.*np.sqrt(3.),
-                                    3.*np.sqrt(3.)]))
+            np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+            data[:, 3],
+            "spherical",
+            [0.0],
+            "spherical",
+            6,
+            False,
+            "euclidean",
+        )
+
+    with pytest.raises(ValueError):
+        core._initialize_variogram_model(
+            np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+            data[:, 3],
+            "linear",
+            [0.0, 0.0],
+            "linear",
+            6,
+            False,
+            "geographic",
+        )
+
+    lags, semivariance, variogram_model_parameters = core._initialize_variogram_model(
+        np.vstack(
+            (
+                np.array([1.0, 2.0, 3.0, 4.0]),
+                np.array([1.0, 2.0, 3.0, 4.0]),
+                np.array([1.0, 2.0, 3.0, 4.0]),
+            )
+        ).T,
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        "linear",
+        [0.0, 0.0],
+        "linear",
+        3,
+        False,
+        "euclidean",
+    )
+    assert_allclose(
+        lags, np.array([np.sqrt(3.0), 2.0 * np.sqrt(3.0), 3.0 * np.sqrt(3.0)])
+    )
     assert_allclose(semivariance, np.array([0.5, 2.0, 4.5]))
 
 
 def test_core_calculate_variogram_model():
 
     res = core._calculate_variogram_model(
-        np.array([1.0, 2.0, 3.0, 4.0]), np.array([2.05, 2.95, 4.05, 4.95]),
-        'linear', variogram_models.linear_variogram_model, False)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([2.05, 2.95, 4.05, 4.95]),
+        "linear",
+        variogram_models.linear_variogram_model,
+        False,
+    )
     assert_allclose(res, np.array([0.98, 1.05]), 0.01, 0.01)
 
     res = core._calculate_variogram_model(
-        np.array([1.0, 2.0, 3.0, 4.0]), np.array([2.05, 2.95, 4.05, 4.95]),
-        'linear', variogram_models.linear_variogram_model, True)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([2.05, 2.95, 4.05, 4.95]),
+        "linear",
+        variogram_models.linear_variogram_model,
+        True,
+    )
     assert_allclose(res, np.array([0.98, 1.05]), 0.01, 0.01)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([1., 2.8284271,
-                                              5.1961524, 8.]),
-        'power', variogram_models.power_variogram_model, False)
-    assert_allclose(res, np.array([1., 1.5, 0.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([1.0, 2.8284271, 5.1961524, 8.0]),
+        "power",
+        variogram_models.power_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([1.0, 1.5, 0.0]), 0.001, 0.001)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([1.0, 1.4142, 1.7321, 2.0]),
-        'power', variogram_models.power_variogram_model, False)
-    assert_allclose(res, np.array([1., 0.5, 0.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([1.0, 1.4142, 1.7321, 2.0]),
+        "power",
+        variogram_models.power_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([1.0, 0.5, 0.0]), 0.001, 0.001)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([1.2642, 1.7293,
-                                              1.9004, 1.9634]),
-        'exponential', variogram_models.exponential_variogram_model, False)
-    assert_allclose(res, np.array([2., 3., 0.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([1.2642, 1.7293, 1.9004, 1.9634]),
+        "exponential",
+        variogram_models.exponential_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([2.0, 3.0, 0.0]), 0.001, 0.001)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([0.5769, 1.4872,
-                                              1.9065, 1.9914]),
-        'gaussian', variogram_models.gaussian_variogram_model, False)
-    assert_allclose(res, np.array([2., 3., 0.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([0.5769, 1.4872, 1.9065, 1.9914]),
+        "gaussian",
+        variogram_models.gaussian_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([2.0, 3.0, 0.0]), 0.001, 0.001)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([3.33060952, 3.85063879,
-                                              3.96667301, 3.99256374]),
-        'exponential', variogram_models.exponential_variogram_model, False)
-    assert_allclose(res, np.array([3., 2., 1.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([3.33060952, 3.85063879, 3.96667301, 3.99256374]),
+        "exponential",
+        variogram_models.exponential_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([3.0, 2.0, 1.0]), 0.001, 0.001)
 
     res = core._calculate_variogram_model(
-        np.array([1., 2., 3., 4.]), np.array([2.60487044, 3.85968813,
-                                              3.99694817, 3.99998564]),
-        'gaussian', variogram_models.gaussian_variogram_model, False)
-    assert_allclose(res, np.array([3., 2., 1.]), 0.001, 0.001)
+        np.array([1.0, 2.0, 3.0, 4.0]),
+        np.array([2.60487044, 3.85968813, 3.99694817, 3.99998564]),
+        "gaussian",
+        variogram_models.gaussian_variogram_model,
+        False,
+    )
+    assert_allclose(res, np.array([3.0, 2.0, 1.0]), 0.001, 0.001)
 
 
 def test_core_krige():
 
     # Example 3.2 from Kitanidis
-    data = np.array([[9.7, 47.6, 1.22],
-                     [43.8, 24.6, 2.822]])
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T, data[:, 2],
-                        np.array([18.8, 67.9]),
-                        variogram_models.linear_variogram_model,
-                        [0.006, 0.1], 'euclidean')
+    data = np.array([[9.7, 47.6, 1.22], [43.8, 24.6, 2.822]])
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1])).T,
+        data[:, 2],
+        np.array([18.8, 67.9]),
+        variogram_models.linear_variogram_model,
+        [0.006, 0.1],
+        "euclidean",
+    )
     assert z == approx(1.6364, rel=1e-4)
     assert ss == approx(0.4201, rel=1e-4)
 
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T, data[:, 2],
-                        np.array([43.8, 24.6]),
-                        variogram_models.linear_variogram_model,
-                        [0.006, 0.1], 'euclidean')
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1])).T,
+        data[:, 2],
+        np.array([43.8, 24.6]),
+        variogram_models.linear_variogram_model,
+        [0.006, 0.1],
+        "euclidean",
+    )
     assert z == approx(2.822, rel=1e-3)
     assert ss == approx(0.0, rel=1e-3)
 
@@ -330,19 +412,26 @@ def test_core_krige():
 def test_core_krige_3d():
 
     # Adapted from example 3.2 from Kitanidis
-    data = np.array([[9.7, 47.6, 1.0, 1.22],
-                     [43.8, 24.6, 1.0, 2.822]])
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
-                        data[:, 3], np.array([18.8, 67.9, 1.0]),
-                        variogram_models.linear_variogram_model,
-                        [0.006, 0.1], 'euclidean')
+    data = np.array([[9.7, 47.6, 1.0, 1.22], [43.8, 24.6, 1.0, 2.822]])
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+        data[:, 3],
+        np.array([18.8, 67.9, 1.0]),
+        variogram_models.linear_variogram_model,
+        [0.006, 0.1],
+        "euclidean",
+    )
     assert z == approx(1.6364, rel=1e-4)
     assert ss == approx(0.4201, rel=1e-4)
 
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
-                        data[:, 3], np.array([43.8, 24.6, 1.0]),
-                        variogram_models.linear_variogram_model,
-                        [0.006, 0.1], 'euclidean')
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1], data[:, 2])).T,
+        data[:, 3],
+        np.array([43.8, 24.6, 1.0]),
+        variogram_models.linear_variogram_model,
+        [0.006, 0.1],
+        "euclidean",
+    )
     assert z == approx(2.822, rel=1e-3)
     assert ss == approx(0.0, rel=1e-3)
 
@@ -355,12 +444,16 @@ def test_ok(validation_ref):
 
     data, (ok_test_answer, gridx, gridy), _ = validation_ref
 
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='exponential',
-                         variogram_parameters=[500.0, 3000.0, 0.0])
-    z, ss = ok.execute('grid', gridx, gridy, backend='vectorized')
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+    )
+    z, ss = ok.execute("grid", gridx, gridy, backend="vectorized")
     assert_allclose(z, ok_test_answer)
-    z, ss = ok.execute('grid', gridx, gridy, backend='loop')
+    z, ss = ok.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z, ok_test_answer)
 
 
@@ -369,8 +462,7 @@ def test_ok_update_variogram_model(validation_ref):
     data, (ok_test_answer, gridx, gridy), _ = validation_ref
 
     with pytest.raises(ValueError):
-        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                        variogram_model='blurg')
+        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="blurg")
 
     ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2])
     variogram_model = ok.variogram_model
@@ -379,10 +471,9 @@ def test_ok_update_variogram_model(validation_ref):
     anisotropy_angle = ok.anisotropy_angle
 
     with pytest.raises(ValueError):
-        ok.update_variogram_model('blurg')
+        ok.update_variogram_model("blurg")
 
-    ok.update_variogram_model('power', anisotropy_scaling=3.0,
-                              anisotropy_angle=45.0)
+    ok.update_variogram_model("power", anisotropy_scaling=3.0, anisotropy_angle=45.0)
 
     # TODO: check that new parameters equal to the set parameters
     assert variogram_model != ok.variogram_model
@@ -402,9 +493,13 @@ def test_ok_get_variogram_points(validation_ref):
 
     data, _, (ok_test_answer, gridx, gridy) = validation_ref
 
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='exponential',
-                          variogram_parameters=_variogram_parameters)
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=_variogram_parameters,
+    )
 
     # Get the variogram points from the UniversalKriging instance
     lags, calculated_variogram = ok.get_variogram_points()
@@ -412,7 +507,8 @@ def test_ok_get_variogram_points(validation_ref):
     # Generate the expected variogram points according to the
     # exponential variogram model
     expected_variogram = variogram_models.exponential_variogram_model(
-                         _variogram_parameters, lags)
+        _variogram_parameters, lags
+    )
 
     assert_allclose(calculated_variogram, expected_variogram)
 
@@ -424,9 +520,9 @@ def test_ok_execute(sample_data_2d):
     ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2])
 
     with pytest.raises(ValueError):
-        ok.execute('blurg', gridx, gridy)
+        ok.execute("blurg", gridx, gridy)
 
-    z, ss = ok.execute('grid', gridx, gridy, backend='vectorized')
+    z, ss = ok.execute("grid", gridx, gridy, backend="vectorized")
     shape = (gridy.size, gridx.size)
     assert z.shape == shape
     assert ss.shape == shape
@@ -434,7 +530,7 @@ def test_ok_execute(sample_data_2d):
     assert np.amax(ss) != np.amin(ss)
     assert not np.ma.is_masked(z)
 
-    z, ss = ok.execute('grid', gridx, gridy, backend='loop')
+    z, ss = ok.execute("grid", gridx, gridy, backend="loop")
     shape = (gridy.size, gridx.size)
     assert z.shape == shape
     assert ss.shape == shape
@@ -443,53 +539,53 @@ def test_ok_execute(sample_data_2d):
     assert not np.ma.is_masked(z)
 
     with pytest.raises(IOError):
-        ok.execute('masked', gridx, gridy, backend='vectorized')
+        ok.execute("masked", gridx, gridy, backend="vectorized")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        ok.execute('masked', gridx, gridy, mask=mask,
-                   backend='vectorized')
-    z, ss = ok.execute('masked', gridx, gridy, mask=mask_ref,
-                       backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+        ok.execute("masked", gridx, gridy, mask=mask, backend="vectorized")
+    z, ss = ok.execute("masked", gridx, gridy, mask=mask_ref, backend="vectorized")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
-    z, ss = ok.execute('masked', gridx, gridy, mask=mask_ref.T,
-                       backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = ok.execute("masked", gridx, gridy, mask=mask_ref.T, backend="vectorized")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
 
     with pytest.raises(IOError):
-        ok.execute('masked', gridx, gridy, backend='loop')
+        ok.execute("masked", gridx, gridy, backend="loop")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        ok.execute('masked', gridx, gridy, mask=mask,
-                   backend='loop')
-    z, ss = ok.execute('masked', gridx, gridy, mask=mask_ref,
-                       backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+        ok.execute("masked", gridx, gridy, mask=mask, backend="loop")
+    z, ss = ok.execute("masked", gridx, gridy, mask=mask_ref, backend="loop")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
-    z, ss = ok.execute('masked', gridx, gridy, mask=mask_ref.T, backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = ok.execute("masked", gridx, gridy, mask=mask_ref.T, backend="loop")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
 
     with pytest.raises(ValueError):
-        ok.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                   backend='vectorized')
-    z, ss = ok.execute('points', gridx[0], gridy[0], backend='vectorized')
+        ok.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            backend="vectorized",
+        )
+    z, ss = ok.execute("points", gridx[0], gridy[0], backend="vectorized")
     assert z.shape == (1,)
     assert ss.shape == (1,)
 
     with pytest.raises(ValueError):
-        ok.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                   backend='loop')
-    z, ss = ok.execute('points', gridx[0], gridy[0], backend='loop')
+        ok.execute(
+            "points", np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]), backend="loop"
+        )
+    z, ss = ok.execute("points", gridx[0], gridy[0], backend="loop")
     assert z.shape == (1,)
     assert ss.shape == (1,)
 
@@ -498,17 +594,19 @@ def test_cython_ok(sample_data_2d):
     data, (gridx, gridy, _), mask_ref = sample_data_2d
 
     ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2])
-    z1, ss1 = ok.execute('grid', gridx, gridy, backend='loop')
-    z2, ss2 = ok.execute('grid', gridx, gridy, backend='C')
+    z1, ss1 = ok.execute("grid", gridx, gridy, backend="loop")
+    z2, ss2 = ok.execute("grid", gridx, gridy, backend="C")
     assert_allclose(z1, z2)
     assert_allclose(ss1, ss2)
 
     closest_points = 4
 
-    z1, ss1 = ok.execute('grid', gridx, gridy, backend='loop',
-                         n_closest_points=closest_points)
-    z2, ss2 = ok.execute('grid', gridx, gridy, backend='C',
-                         n_closest_points=closest_points)
+    z1, ss1 = ok.execute(
+        "grid", gridx, gridy, backend="loop", n_closest_points=closest_points
+    )
+    z2, ss2 = ok.execute(
+        "grid", gridx, gridy, backend="C", n_closest_points=closest_points
+    )
     assert_allclose(z1, z2)
     assert_allclose(ss1, ss2)
 
@@ -521,13 +619,17 @@ def test_uk(validation_ref):
 
     data, _, (uk_test_answer, gridx, gridy) = validation_ref
 
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='exponential',
-                          variogram_parameters=[500.0, 3000.0, 0.0],
-                          drift_terms=['regional_linear'])
-    z, ss = uk.execute('grid', gridx, gridy, backend='vectorized')
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+        drift_terms=["regional_linear"],
+    )
+    z, ss = uk.execute("grid", gridx, gridy, backend="vectorized")
     assert_allclose(z, uk_test_answer)
-    z, ss = uk.execute('grid', gridx, gridy, backend='loop')
+    z, ss = uk.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z, uk_test_answer)
 
 
@@ -536,18 +638,19 @@ def test_uk_update_variogram_model(sample_data_2d):
     data, (gridx, gridy, _), mask_ref = sample_data_2d
 
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='blurg')
+        UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="blurg")
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         drift_terms=['external_Z'])
+        UniversalKriging(data[:, 0], data[:, 1], data[:, 2], drift_terms=["external_Z"])
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         drift_terms=['external_Z'],
-                         external_drift=np.array([0]))
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            drift_terms=["external_Z"],
+            external_drift=np.array([0]),
+        )
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         drift_terms=['point_log'])
+        UniversalKriging(data[:, 0], data[:, 1], data[:, 2], drift_terms=["point_log"])
 
     uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2])
     variogram_model = uk.variogram_model
@@ -556,9 +659,8 @@ def test_uk_update_variogram_model(sample_data_2d):
     anisotropy_angle = uk.anisotropy_angle
 
     with pytest.raises(ValueError):
-        uk.update_variogram_model('blurg')
-    uk.update_variogram_model('power', anisotropy_scaling=3.0,
-                              anisotropy_angle=45.0)
+        uk.update_variogram_model("blurg")
+    uk.update_variogram_model("power", anisotropy_scaling=3.0, anisotropy_angle=45.0)
     # TODO: check that the new parameters are equal to the expected ones
     assert variogram_model != uk.variogram_model
     assert variogram_parameters != uk.variogram_model_parameters
@@ -577,10 +679,14 @@ def test_uk_get_variogram_points(validation_ref):
 
     data, _, (uk_test_answer, gridx, gridy) = validation_ref
 
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='exponential',
-                          variogram_parameters=_variogram_parameters,
-                          drift_terms=['regional_linear'])
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=_variogram_parameters,
+        drift_terms=["regional_linear"],
+    )
 
     # Get the variogram points from the UniversalKriging instance
     lags, calculated_variogram = uk.get_variogram_points()
@@ -588,7 +694,8 @@ def test_uk_get_variogram_points(validation_ref):
     # Generate the expected variogram points according to the
     # exponential variogram model
     expected_variogram = variogram_models.exponential_variogram_model(
-                         _variogram_parameters, lags)
+        _variogram_parameters, lags
+    )
 
     assert_allclose(calculated_variogram, expected_variogram)
 
@@ -603,29 +710,48 @@ def test_uk_calculate_data_point_zscalars(sample_data_2d):
     dem_y = np.arange(0.0, 6.0, 1.0)
 
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear',
-                         variogram_parameters=[1.0, 0.0],
-                         drift_terms=['external_Z'])
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            variogram_parameters=[1.0, 0.0],
+            drift_terms=["external_Z"],
+        )
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear',
-                         variogram_parameters=[1.0, 0.0],
-                         drift_terms=['external_Z'], external_drift=dem)
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            variogram_parameters=[1.0, 0.0],
+            drift_terms=["external_Z"],
+            external_drift=dem,
+        )
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear',
-                         variogram_parameters=[1.0, 0.0],
-                         drift_terms=['external_Z'],
-                         external_drift=dem, external_drift_x=dem_x,
-                         external_drift_y=np.arange(0.0, 5.0, 1.0))
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            variogram_parameters=[1.0, 0.0],
+            drift_terms=["external_Z"],
+            external_drift=dem,
+            external_drift_x=dem_x,
+            external_drift_y=np.arange(0.0, 5.0, 1.0),
+        )
 
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='linear',
-                          variogram_parameters=[1.0, 0.0],
-                          drift_terms=['external_Z'],
-                          external_drift=dem, external_drift_x=dem_x,
-                          external_drift_y=dem_y)
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.0],
+        drift_terms=["external_Z"],
+        external_drift=dem,
+        external_drift_x=dem_x,
+        external_drift_y=dem_y,
+    )
     assert_allclose(uk.z_scalars, data[:, 0])
 
     xi, yi = np.meshgrid(np.arange(0.0, 5.3, 0.1), gridy)
@@ -640,33 +766,42 @@ def test_uk_calculate_data_point_zscalars(sample_data_2d):
 def test_uk_execute_single_point():
 
     # Test data and answer from lecture notes by Nicolas Christou, UCLA Stats
-    data = np.array([[61.0, 139.0, 477.0],
-                     [63.0, 140.0, 696.0],
-                     [64.0, 129.0, 227.0],
-                     [68.0, 128.0, 646.0],
-                     [71.0, 140.0, 606.0],
-                     [73.0, 141.0, 791.0],
-                     [75.0, 128.0, 783.0]])
+    data = np.array(
+        [
+            [61.0, 139.0, 477.0],
+            [63.0, 140.0, 696.0],
+            [64.0, 129.0, 227.0],
+            [68.0, 128.0, 646.0],
+            [71.0, 140.0, 606.0],
+            [73.0, 141.0, 791.0],
+            [75.0, 128.0, 783.0],
+        ]
+    )
     point = (65.0, 137.0)
     z_answer = 567.54
     ss_answer = 9.044
 
     uk = UniversalKriging(
-            data[:, 0], data[:, 1], data[:, 2], variogram_model='exponential',
-            variogram_parameters=[10.0, 9.99, 0.0],
-            drift_terms=['regional_linear'])
-    z, ss = uk.execute('points', np.array([point[0]]), np.array([point[1]]),
-                       backend='vectorized')
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[10.0, 9.99, 0.0],
+        drift_terms=["regional_linear"],
+    )
+    z, ss = uk.execute(
+        "points", np.array([point[0]]), np.array([point[1]]), backend="vectorized"
+    )
     assert z_answer == approx(z[0], rel=0.1)
     assert ss_answer == approx(ss[0], rel=0.1)
 
-    z, ss = uk.execute('points', np.array([61.0]), np.array([139.0]),
-                       backend='vectorized')
+    z, ss = uk.execute(
+        "points", np.array([61.0]), np.array([139.0]), backend="vectorized"
+    )
     assert z[0] == approx(477.0, rel=1e-3)
     assert ss[0] == approx(0.0, rel=1e-3)
 
-    z, ss = uk.execute('points', np.array([61.0]), np.array([139.0]),
-                       backend='loop')
+    z, ss = uk.execute("points", np.array([61.0]), np.array([139.0]), backend="loop")
     assert z[0] == approx(477.0, rel=1e-3)
     assert ss[0] == approx(0.0, rel=1e-3)
 
@@ -676,15 +811,19 @@ def test_uk_execute(sample_data_2d):
     data, (gridx, gridy, _), mask_ref = sample_data_2d
 
     uk = UniversalKriging(
-            data[:, 0], data[:, 1], data[:, 2],
-            variogram_model='linear', drift_terms=['regional_linear'])
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear"],
+    )
 
     with pytest.raises(ValueError):
-        uk.execute('blurg', gridx, gridy)
+        uk.execute("blurg", gridx, gridy)
     with pytest.raises(ValueError):
-        uk.execute('grid', gridx, gridy, backend='mrow')
+        uk.execute("grid", gridx, gridy, backend="mrow")
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='vectorized')
+    z, ss = uk.execute("grid", gridx, gridy, backend="vectorized")
     shape = (gridy.size, gridx.size)
     assert z.shape == shape
     assert ss.shape == shape
@@ -692,7 +831,7 @@ def test_uk_execute(sample_data_2d):
     assert np.amax(ss) != np.amin(ss)
     assert not np.ma.is_masked(z)
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='loop')
+    z, ss = uk.execute("grid", gridx, gridy, backend="loop")
     shape = (gridy.size, gridx.size)
     assert z.shape == shape
     assert ss.shape == shape
@@ -701,52 +840,53 @@ def test_uk_execute(sample_data_2d):
     assert not np.ma.is_masked(z)
 
     with pytest.raises(IOError):
-        uk.execute('masked', gridx, gridy, backend='vectorized')
+        uk.execute("masked", gridx, gridy, backend="vectorized")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        uk.execute('masked', gridx, gridy, mask=mask,
-                   backend='vectorized')
-    z, ss = uk.execute('masked', gridx, gridy, mask=mask_ref,
-                       backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+        uk.execute("masked", gridx, gridy, mask=mask, backend="vectorized")
+    z, ss = uk.execute("masked", gridx, gridy, mask=mask_ref, backend="vectorized")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
-    z, ss = uk.execute('masked', gridx, gridy, mask=mask_ref.T,
-                       backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = uk.execute("masked", gridx, gridy, mask=mask_ref.T, backend="vectorized")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
 
     with pytest.raises(IOError):
-        uk.execute('masked', gridx, gridy, backend='loop')
+        uk.execute("masked", gridx, gridy, backend="loop")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        uk.execute('masked', gridx, gridy, mask=mask,
-                   backend='loop')
-    z, ss = uk.execute('masked', gridx, gridy, mask=mask_ref, backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+        uk.execute("masked", gridx, gridy, mask=mask, backend="loop")
+    z, ss = uk.execute("masked", gridx, gridy, mask=mask_ref, backend="loop")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
-    z, ss = uk.execute('masked', gridx, gridy, mask=mask_ref.T, backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = uk.execute("masked", gridx, gridy, mask=mask_ref.T, backend="loop")
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0] is np.ma.masked
     assert ss[0, 0] is np.ma.masked
 
     with pytest.raises(ValueError):
-        uk.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                   backend='vectorized')
-    z, ss = uk.execute('points', gridx[0], gridy[0], backend='vectorized')
+        uk.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            backend="vectorized",
+        )
+    z, ss = uk.execute("points", gridx[0], gridy[0], backend="vectorized")
     assert z.shape == (1,)
     assert ss.shape == (1,)
 
     with pytest.raises(ValueError):
-        uk.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                   backend='loop')
-    z, ss = uk.execute('points', gridx[0], gridy[0], backend='loop')
+        uk.execute(
+            "points", np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]), backend="loop"
+        )
+    z, ss = uk.execute("points", gridx[0], gridy[0], backend="loop")
     assert z.shape == (1,)
     assert ss.shape == (1,)
 
@@ -757,19 +897,29 @@ def test_ok_uk_produce_same_result(validation_ref):
 
     gridx = np.linspace(1067000.0, 1072000.0, 100)
     gridy = np.linspace(241500.0, 244000.0, 100)
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', verbose=False,
-                         enable_plotting=False)
-    z_ok, ss_ok = ok.execute('grid', gridx, gridy, backend='vectorized')
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='linear', verbose=False,
-                          enable_plotting=False)
-    z_uk, ss_uk = uk.execute('grid', gridx, gridy, backend='vectorized')
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+    )
+    z_ok, ss_ok = ok.execute("grid", gridx, gridy, backend="vectorized")
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+    )
+    z_uk, ss_uk = uk.execute("grid", gridx, gridy, backend="vectorized")
     assert_allclose(z_ok, z_uk)
     assert_allclose(ss_ok, ss_uk)
 
-    z_ok, ss_ok = ok.execute('grid', gridx, gridy, backend='loop')
-    z_uk, ss_uk = uk.execute('grid', gridx, gridy, backend='loop')
+    z_ok, ss_ok = ok.execute("grid", gridx, gridy, backend="loop")
+    z_uk, ss_uk = uk.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z_ok, z_uk)
     assert_allclose(ss_ok, ss_uk)
 
@@ -780,11 +930,16 @@ def test_ok_backends_produce_same_result(validation_ref):
 
     gridx = np.linspace(1067000.0, 1072000.0, 100)
     gridy = np.linspace(241500.0, 244000.0, 100)
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', verbose=False,
-                         enable_plotting=False)
-    z_ok_v, ss_ok_v = ok.execute('grid', gridx, gridy, backend='vectorized')
-    z_ok_l, ss_ok_l = ok.execute('grid', gridx, gridy, backend='loop')
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+    )
+    z_ok_v, ss_ok_v = ok.execute("grid", gridx, gridy, backend="vectorized")
+    z_ok_l, ss_ok_l = ok.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z_ok_v, z_ok_l)
     assert_allclose(ss_ok_v, ss_ok_l)
 
@@ -795,11 +950,16 @@ def test_uk_backends_produce_same_result(validation_ref):
 
     gridx = np.linspace(1067000.0, 1072000.0, 100)
     gridy = np.linspace(241500.0, 244000.0, 100)
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='linear', verbose=False,
-                          enable_plotting=False)
-    z_uk_v, ss_uk_v = uk.execute('grid', gridx, gridy, backend='vectorized')
-    z_uk_l, ss_uk_l = uk.execute('grid', gridx, gridy, backend='loop')
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+    )
+    z_uk_v, ss_uk_v = uk.execute("grid", gridx, gridy, backend="vectorized")
+    z_uk_l, ss_uk_l = uk.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z_uk_v, z_uk_l)
     assert_allclose(ss_uk_v, ss_uk_l)
 
@@ -809,42 +969,61 @@ def test_kriging_tools(sample_data_2d):
     data, (gridx, gridy, gridx_2), mask_ref = sample_data_2d
 
     ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2])
-    z_write, ss_write = ok.execute('grid', gridx, gridy)
+    z_write, ss_write = ok.execute("grid", gridx, gridy)
 
-    kt.write_asc_grid(gridx, gridy, z_write,
-                      filename=os.path.join(BASE_DIR, 'test_data/temp.asc'),
-                      style=1)
+    kt.write_asc_grid(
+        gridx,
+        gridy,
+        z_write,
+        filename=os.path.join(BASE_DIR, "test_data/temp.asc"),
+        style=1,
+    )
     z_read, x_read, y_read, cellsize, no_data = kt.read_asc_grid(
-            os.path.join(BASE_DIR, 'test_data/temp.asc'))
+        os.path.join(BASE_DIR, "test_data/temp.asc")
+    )
     assert_allclose(z_write, z_read, 0.01, 0.01)
     assert_allclose(gridx, x_read)
     assert_allclose(gridy, y_read)
 
-    z_write, ss_write = ok.execute('masked', gridx, gridy, mask=mask_ref)
-    kt.write_asc_grid(gridx, gridy, z_write,
-                      filename=os.path.join(BASE_DIR, 'test_data/temp.asc'),
-                      style=1)
+    z_write, ss_write = ok.execute("masked", gridx, gridy, mask=mask_ref)
+    kt.write_asc_grid(
+        gridx,
+        gridy,
+        z_write,
+        filename=os.path.join(BASE_DIR, "test_data/temp.asc"),
+        style=1,
+    )
     z_read, x_read, y_read, cellsize, no_data = kt.read_asc_grid(
-            os.path.join(BASE_DIR, 'test_data/temp.asc'))
-    assert (np.ma.allclose(z_write,
-                           np.ma.masked_where(z_read == no_data, z_read),
-                           masked_equal=True, rtol=0.01, atol=0.01))
+        os.path.join(BASE_DIR, "test_data/temp.asc")
+    )
+    assert np.ma.allclose(
+        z_write,
+        np.ma.masked_where(z_read == no_data, z_read),
+        masked_equal=True,
+        rtol=0.01,
+        atol=0.01,
+    )
     assert_allclose(gridx, x_read)
     assert_allclose(gridy, y_read)
 
     ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2])
-    z_write, ss_write = ok.execute('grid', gridx_2, gridy)
+    z_write, ss_write = ok.execute("grid", gridx_2, gridy)
 
-    kt.write_asc_grid(gridx_2, gridy, z_write,
-                      filename=os.path.join(BASE_DIR, 'test_data/temp.asc'),
-                      style=2)
+    kt.write_asc_grid(
+        gridx_2,
+        gridy,
+        z_write,
+        filename=os.path.join(BASE_DIR, "test_data/temp.asc"),
+        style=2,
+    )
     z_read, x_read, y_read, cellsize, no_data = kt.read_asc_grid(
-            os.path.join(BASE_DIR, 'test_data/temp.asc'))
+        os.path.join(BASE_DIR, "test_data/temp.asc")
+    )
     assert_allclose(z_write, z_read, 0.01, 0.01)
     assert_allclose(gridx_2, x_read)
     assert_allclose(gridy, y_read)
 
-    os.remove(os.path.join(BASE_DIR, 'test_data/temp.asc'))
+    os.remove(os.path.join(BASE_DIR, "test_data/temp.asc"))
 
 
 # http://doc.pytest.org/en/latest/skipping.html#id1
@@ -860,13 +1039,18 @@ def test_uk_three_primary_drifts(sample_data_2d):
     dem_y = np.arange(0.0, 6.0, 1.0)
 
     uk = UniversalKriging(
-            data[:, 0], data[:, 1], data[:, 2],
-            variogram_model='linear',
-            drift_terms=['regional_linear', 'external_Z', 'point_log'],
-            point_drift=well, external_drift=dem,
-            external_drift_x=dem_x, external_drift_y=dem_y)
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear", "external_Z", "point_log"],
+        point_drift=well,
+        external_drift=dem,
+        external_drift_x=dem_x,
+        external_drift_y=dem_y,
+    )
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='vectorized')
+    z, ss = uk.execute("grid", gridx, gridy, backend="vectorized")
     assert z.shape == (gridy.shape[0], gridx.shape[0])
     assert ss.shape == (gridy.shape[0], gridx.shape[0])
     assert np.all(np.isfinite(z))
@@ -874,7 +1058,7 @@ def test_uk_three_primary_drifts(sample_data_2d):
     assert np.all(np.isfinite(ss))
     assert not np.all(np.isnan(ss))
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='loop')
+    z, ss = uk.execute("grid", gridx, gridy, backend="loop")
     assert z.shape == (gridy.shape[0], gridx.shape[0])
     assert ss.shape == (gridy.shape[0], gridx.shape[0])
     assert np.all(np.isfinite(z))
@@ -889,80 +1073,125 @@ def test_uk_specified_drift(sample_data_2d):
 
     xg, yg = np.meshgrid(gridx, gridy)
     well = np.array([[1.1, 1.1, -1.0]])
-    point_log = well[0, 2] * np.log(np.sqrt((xg - well[0, 0])**2.
-                                            + (yg - well[0, 1])**2.)) * -1.
+    point_log = (
+        well[0, 2]
+        * np.log(np.sqrt((xg - well[0, 0]) ** 2.0 + (yg - well[0, 1]) ** 2.0))
+        * -1.0
+    )
     if np.any(np.isinf(point_log)):
-        point_log[np.isinf(point_log)] = -100. * well[0, 2] * -1.
-    point_log_data = well[0, 2] * np.log(
-            np.sqrt((data[:, 0] - well[0, 0])**2. +
-                    (data[:, 1] - well[0, 1])**2.)) * -1.
+        point_log[np.isinf(point_log)] = -100.0 * well[0, 2] * -1.0
+    point_log_data = (
+        well[0, 2]
+        * np.log(
+            np.sqrt((data[:, 0] - well[0, 0]) ** 2.0 + (data[:, 1] - well[0, 1]) ** 2.0)
+        )
+        * -1.0
+    )
     if np.any(np.isinf(point_log_data)):
-        point_log_data[np.isinf(point_log_data)] = -100. * well[0, 2] * -1.
+        point_log_data[np.isinf(point_log_data)] = -100.0 * well[0, 2] * -1.0
 
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', drift_terms=['specified'])
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            drift_terms=["specified"],
+        )
     with pytest.raises(TypeError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', drift_terms=['specified'],
-                         specified_drift=data[:, 0])
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            drift_terms=["specified"],
+            specified_drift=data[:, 0],
+        )
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', drift_terms=['specified'],
-                         specified_drift=[data[:2, 0]])
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            drift_terms=["specified"],
+            specified_drift=[data[:2, 0]],
+        )
 
-    uk_spec = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['specified'],
-                               specified_drift=[data[:, 0], data[:, 1]])
+    uk_spec = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["specified"],
+        specified_drift=[data[:, 0], data[:, 1]],
+    )
     with pytest.raises(ValueError):
-        uk_spec.execute('grid', gridx, gridy,
-                        specified_drift_arrays=[gridx, gridy])
+        uk_spec.execute("grid", gridx, gridy, specified_drift_arrays=[gridx, gridy])
     with pytest.raises(TypeError):
-        uk_spec.execute('grid', gridx, gridy,
-                        specified_drift_arrays=gridx)
+        uk_spec.execute("grid", gridx, gridy, specified_drift_arrays=gridx)
     with pytest.raises(ValueError):
-        uk_spec.execute('grid', gridx, gridy,
-                        specified_drift_arrays=[xg])
-    z_spec, ss_spec = uk_spec.execute('grid', gridx, gridy,
-                                      specified_drift_arrays=[xg, yg])
-
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['regional_linear'])
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
-
-    assert_allclose(z_spec, z_lin)
-    assert_allclose(ss_spec, ss_lin)
-
-    uk_spec = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['specified'],
-                               specified_drift=[point_log_data])
-    z_spec, ss_spec = uk_spec.execute('grid', gridx, gridy,
-                                      specified_drift_arrays=[point_log])
-
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['point_log'], point_drift=well)
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
-
-    assert_allclose(z_spec, z_lin)
-    assert_allclose(ss_spec, ss_lin)
-
-    uk_spec = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['specified'],
-                               specified_drift=[data[:, 0], data[:, 1],
-                               point_log_data])
+        uk_spec.execute("grid", gridx, gridy, specified_drift_arrays=[xg])
     z_spec, ss_spec = uk_spec.execute(
-            'grid', gridx, gridy,
-            specified_drift_arrays=[xg, yg, point_log])
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['regional_linear', 'point_log'],
-                              point_drift=well)
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
+        "grid", gridx, gridy, specified_drift_arrays=[xg, yg]
+    )
+
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear"],
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
+
+    assert_allclose(z_spec, z_lin)
+    assert_allclose(ss_spec, ss_lin)
+
+    uk_spec = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["specified"],
+        specified_drift=[point_log_data],
+    )
+    z_spec, ss_spec = uk_spec.execute(
+        "grid", gridx, gridy, specified_drift_arrays=[point_log]
+    )
+
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["point_log"],
+        point_drift=well,
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
+
+    assert_allclose(z_spec, z_lin)
+    assert_allclose(ss_spec, ss_lin)
+
+    uk_spec = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["specified"],
+        specified_drift=[data[:, 0], data[:, 1], point_log_data],
+    )
+    z_spec, ss_spec = uk_spec.execute(
+        "grid", gridx, gridy, specified_drift_arrays=[xg, yg, point_log]
+    )
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear", "point_log"],
+        point_drift=well,
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
 
     assert_allclose(z_spec, z_lin)
     assert_allclose(ss_spec, ss_lin)
@@ -977,52 +1206,87 @@ def test_uk_functional_drift(sample_data_2d):
     func_y = lambda x, y: y  # noqa
 
     def func_well(x, y):
-        return - well[0, 2] * np.log(
-                np.sqrt((x - well[0, 0])**2. + (y - well[0, 1])**2.))
+        return -well[0, 2] * np.log(
+            np.sqrt((x - well[0, 0]) ** 2.0 + (y - well[0, 1]) ** 2.0)
+        )
 
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', drift_terms=['functional'])
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            drift_terms=["functional"],
+        )
     with pytest.raises(TypeError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear', drift_terms=['functional'],
-                         functional_drift=func_x)
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="linear",
+            drift_terms=["functional"],
+            functional_drift=func_x,
+        )
 
-    uk_func = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['functional'],
-                               functional_drift=[func_x, func_y])
-    z_func, ss_func = uk_func.execute('grid', gridx, gridy)
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['regional_linear'])
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
+    uk_func = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["functional"],
+        functional_drift=[func_x, func_y],
+    )
+    z_func, ss_func = uk_func.execute("grid", gridx, gridy)
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear"],
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
     assert_allclose(z_func, z_lin)
     assert_allclose(ss_func, ss_lin)
 
-    uk_func = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['functional'],
-                               functional_drift=[func_well])
-    z_func, ss_func = uk_func.execute('grid', gridx, gridy)
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['point_log'],
-                              point_drift=well)
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
+    uk_func = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["functional"],
+        functional_drift=[func_well],
+    )
+    z_func, ss_func = uk_func.execute("grid", gridx, gridy)
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["point_log"],
+        point_drift=well,
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
     assert_allclose(z_func, z_lin)
     assert_allclose(ss_func, ss_lin)
 
-    uk_func = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                               variogram_model='linear',
-                               drift_terms=['functional'],
-                               functional_drift=[func_x, func_y, func_well])
-    z_func, ss_func = uk_func.execute('grid', gridx, gridy)
-    uk_lin = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                              variogram_model='linear',
-                              drift_terms=['regional_linear', 'point_log'],
-                              point_drift=well)
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy)
+    uk_func = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["functional"],
+        functional_drift=[func_x, func_y, func_well],
+    )
+    z_func, ss_func = uk_func.execute("grid", gridx, gridy)
+    uk_lin = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        drift_terms=["regional_linear", "point_log"],
+        point_drift=well,
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy)
     assert_allclose(z_func, z_lin)
     assert_allclose(ss_func, ss_lin)
 
@@ -1031,34 +1295,44 @@ def test_uk_with_external_drift(validation_ref):
 
     data, _, (uk_test_answer, gridx_ref, gridy_ref) = validation_ref
 
-    dem, demx, demy, cellsize, no_data = \
-        kt.read_asc_grid(os.path.join(BASE_DIR, 'test_data/test3_dem.asc'))
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='spherical',
-                          variogram_parameters=[500.0, 3000.0, 0.0],
-                          anisotropy_scaling=1.0, anisotropy_angle=0.0,
-                          drift_terms=['external_Z'], external_drift=dem,
-                          external_drift_x=demx, external_drift_y=demy,
-                          verbose=False)
-    answer, gridx, gridy, cellsize, no_data = \
-        kt.read_asc_grid(os.path.join(BASE_DIR, 'test_data/test3_answer.asc'))
+    dem, demx, demy, cellsize, no_data = kt.read_asc_grid(
+        os.path.join(BASE_DIR, "test_data/test3_dem.asc")
+    )
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="spherical",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+        anisotropy_scaling=1.0,
+        anisotropy_angle=0.0,
+        drift_terms=["external_Z"],
+        external_drift=dem,
+        external_drift_x=demx,
+        external_drift_y=demy,
+        verbose=False,
+    )
+    answer, gridx, gridy, cellsize, no_data = kt.read_asc_grid(
+        os.path.join(BASE_DIR, "test_data/test3_answer.asc")
+    )
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='vectorized')
+    z, ss = uk.execute("grid", gridx, gridy, backend="vectorized")
     assert_allclose(z, answer, **allclose_pars)
 
-    z, ss = uk.execute('grid', gridx, gridy, backend='loop')
+    z, ss = uk.execute("grid", gridx, gridy, backend="loop")
     assert_allclose(z, answer, **allclose_pars)
 
 
 def test_force_exact():
-    data = np.array([[1., 1., 2.],
-                     [2., 2., 1.5],
-                     [3., 3., 1.]])
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear',
-                         variogram_parameters=[1.0, 1.0])
-    z, ss = ok.execute('grid', [1., 2., 3.], [1., 2., 3.],
-                       backend='vectorized')
+    data = np.array([[1.0, 1.0, 2.0], [2.0, 2.0, 1.5], [3.0, 3.0, 1.0]])
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 1.0],
+    )
+    z, ss = ok.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="vectorized")
     assert z[0, 0] == approx(2.0)
     assert ss[0, 0] == approx(0.0)
     assert z[1, 1] == approx(1.5)
@@ -1067,21 +1341,23 @@ def test_force_exact():
     assert ss[2, 2] == approx(0.0)
     assert ss[0, 2] != approx(0.0)
     assert ss[2, 0] != approx(0.0)
-    z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
-                       backend='vectorized')
+    z, ss = ok.execute(
+        "points", [1.0, 2.0, 3.0, 3.0], [2.0, 1.0, 1.0, 3.0], backend="vectorized"
+    )
     assert ss[0] != approx(0.0)
     assert ss[1] != approx(0.0)
     assert ss[2] != approx(0.0)
     assert z[3] == approx(1.0)
     assert ss[3] == approx(0.0)
-    z, ss = ok.execute('grid', np.arange(0., 4., 0.1),
-                       np.arange(0., 4., 0.1), backend='vectorized')
-    assert z[10, 10] == approx(2.)
-    assert ss[10, 10] == approx(0.)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 4.0, 0.1), np.arange(0.0, 4.0, 0.1), backend="vectorized"
+    )
+    assert z[10, 10] == approx(2.0)
+    assert ss[10, 10] == approx(0.0)
     assert z[20, 20] == approx(1.5)
-    assert ss[20, 20] == approx(0.)
+    assert ss[20, 20] == approx(0.0)
     assert z[30, 30] == approx(1.0)
-    assert ss[30, 30] == approx(0.)
+    assert ss[30, 30] == approx(0.0)
     assert ss[0, 0] != approx(0.0)
     assert ss[15, 15] != approx(0.0)
     assert ss[10, 0] != approx(0.0)
@@ -1090,72 +1366,86 @@ def test_force_exact():
     assert ss[10, 20] != approx(0.0)
     assert ss[30, 20] != approx(0.0)
     assert ss[20, 30] != approx(0.0)
-    z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='vectorized')
-    assert (np.any(ss <= 1e-15))
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
+    )
+    assert np.any(ss <= 1e-15)
     assert not np.any(ss[:9, :30] <= 1e-15)
-    assert not np.allclose(z[:9, :30], 0.)
-    z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='vectorized')
-    assert not np.any(ss <= 1e-15)
-    z, ss = ok.execute('masked', np.arange(2.5, 3.5, 0.1),
-                       np.arange(2.5, 3.5, 0.25), backend='vectorized',
-                       mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1),
-                                       np.arange(2.5, 3.5, 0.25))[0] == 0.))
-    assert (ss[2, 5] <= 1e-15)
-    assert not np.allclose(ss, 0.)
-
-    z, ss = ok.execute('grid', [1., 2., 3.], [1., 2., 3.], backend='loop')
-    assert z[0, 0] == approx(2.0)
-    assert ss[0, 0] == approx(0.0)
-    assert z[1, 1] == approx(1.5)
-    assert ss[1, 1] == approx(0.0)
-    assert z[2, 2] == approx(1.0)
-    assert ss[2, 2] == approx(0.0)
-    assert ss[0, 2] != approx(0.0)
-    assert ss[2, 0] != approx(0.0)
-    z, ss = ok.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
-                       backend='loop')
-    assert ss[0] != approx(0.0)
-    assert ss[1] != approx(0.0)
-    assert ss[2] != approx(0.0)
-    assert z[3] == approx(1.0)
-    assert ss[3] == approx(0.0)
-    z, ss = ok.execute('grid', np.arange(0., 4., 0.1),
-                       np.arange(0., 4., 0.1), backend='loop')
-    assert z[10, 10] == approx(2.)
-    assert ss[10, 10] == approx(0.)
-    assert z[20, 20] == approx(1.5)
-    assert ss[20, 20] == approx(0.)
-    assert z[30, 30] == approx(1.0)
-    assert ss[30, 30] == approx(0.)
-    assert ss[0, 0] != approx(0.0)
-    assert ss[15, 15] != approx(0.0)
-    assert ss[10, 0] != approx(0.0)
-    assert ss[0, 10] != approx(0.0)
-    assert ss[20, 10] != approx(0.0)
-    assert ss[10, 20] != approx(0.0)
-    assert ss[30, 20] != approx(0.0)
-    assert ss[20, 30] != approx(0.0)
-    z, ss = ok.execute('grid', np.arange(0., 3.1, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='loop')
-    assert (np.any(ss <= 1e-15))
-    assert not np.any(ss[:9, :30] <= 1e-15)
-    assert not np.allclose(z[:9, :30], 0.)
-    z, ss = ok.execute('grid', np.arange(0., 1.9, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='loop')
+    assert not np.allclose(z[:9, :30], 0.0)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
+    )
     assert not np.any(ss <= 1e-15)
     z, ss = ok.execute(
-            'masked', np.arange(2.5, 3.5, 0.1),
-            np.arange(2.5, 3.5, 0.25), backend='loop',
-            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1),
-                                        np.arange(2.5, 3.5, 0.25))[0] == 0.))
+        "masked",
+        np.arange(2.5, 3.5, 0.1),
+        np.arange(2.5, 3.5, 0.25),
+        backend="vectorized",
+        mask=np.asarray(
+            np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
+        ),
+    )
     assert ss[2, 5] <= 1e-15
-    assert not np.allclose(ss, 0.)
+    assert not np.allclose(ss, 0.0)
+
+    z, ss = ok.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="loop")
+    assert z[0, 0] == approx(2.0)
+    assert ss[0, 0] == approx(0.0)
+    assert z[1, 1] == approx(1.5)
+    assert ss[1, 1] == approx(0.0)
+    assert z[2, 2] == approx(1.0)
+    assert ss[2, 2] == approx(0.0)
+    assert ss[0, 2] != approx(0.0)
+    assert ss[2, 0] != approx(0.0)
+    z, ss = ok.execute(
+        "points", [1.0, 2.0, 3.0, 3.0], [2.0, 1.0, 1.0, 3.0], backend="loop"
+    )
+    assert ss[0] != approx(0.0)
+    assert ss[1] != approx(0.0)
+    assert ss[2] != approx(0.0)
+    assert z[3] == approx(1.0)
+    assert ss[3] == approx(0.0)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 4.0, 0.1), np.arange(0.0, 4.0, 0.1), backend="loop"
+    )
+    assert z[10, 10] == approx(2.0)
+    assert ss[10, 10] == approx(0.0)
+    assert z[20, 20] == approx(1.5)
+    assert ss[20, 20] == approx(0.0)
+    assert z[30, 30] == approx(1.0)
+    assert ss[30, 30] == approx(0.0)
+    assert ss[0, 0] != approx(0.0)
+    assert ss[15, 15] != approx(0.0)
+    assert ss[10, 0] != approx(0.0)
+    assert ss[0, 10] != approx(0.0)
+    assert ss[20, 10] != approx(0.0)
+    assert ss[10, 20] != approx(0.0)
+    assert ss[30, 20] != approx(0.0)
+    assert ss[20, 30] != approx(0.0)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
+    )
+    assert np.any(ss <= 1e-15)
+    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert not np.allclose(z[:9, :30], 0.0)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
+    )
+    assert not np.any(ss <= 1e-15)
+    z, ss = ok.execute(
+        "masked",
+        np.arange(2.5, 3.5, 0.1),
+        np.arange(2.5, 3.5, 0.25),
+        backend="loop",
+        mask=np.asarray(
+            np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
+        ),
+    )
+    assert ss[2, 5] <= 1e-15
+    assert not np.allclose(ss, 0.0)
 
     uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2])
-    z, ss = uk.execute('grid', [1., 2., 3.], [1., 2., 3.],
-                       backend='vectorized')
+    z, ss = uk.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="vectorized")
     assert z[0, 0] == approx(2.0)
     assert ss[0, 0] == approx(0.0)
     assert z[1, 1] == approx(1.5)
@@ -1164,68 +1454,23 @@ def test_force_exact():
     assert ss[2, 2] == approx(0.0)
     assert ss[0, 2] != approx(0.0)
     assert ss[2, 0] != approx(0.0)
-    z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
-                       backend='vectorized')
-    assert ss[0] != approx(0.0)
-    assert ss[1] != approx(0.0)
-    assert ss[2] != approx(0.0)
-    assert z[3] == approx(1.0)
-    assert ss[3] == approx(0.0)
-    z, ss = uk.execute('grid', np.arange(0., 4., 0.1),
-                       np.arange(0., 4., 0.1), backend='vectorized')
-    assert z[10, 10] == approx(2.)
-    assert ss[10, 10] == approx(0.)
-    assert z[20, 20] == approx(1.5)
-    assert ss[20, 20] == approx(0.)
-    assert z[30, 30] == approx(1.0)
-    assert ss[30, 30] == approx(0.)
-    assert ss[0, 0] != approx(0.0)
-    assert ss[15, 15] != approx(0.0)
-    assert ss[10, 0] != approx(0.0)
-    assert ss[0, 10] != approx(0.0)
-    assert ss[20, 10] != approx(0.0)
-    assert ss[10, 20] != approx(0.0)
-    assert ss[30, 20] != approx(0.0)
-    assert ss[20, 30] != approx(0.0)
-    z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='vectorized')
-    assert np.any(ss <= 1e-15)
-    assert not np.any(ss[:9, :30] <= 1e-15)
-    assert not np.allclose(z[:9, :30], 0.)
-    z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='vectorized')
-    assert not(np.any(ss <= 1e-15))
     z, ss = uk.execute(
-            'masked', np.arange(2.5, 3.5, 0.1),
-            np.arange(2.5, 3.5, 0.25), backend='vectorized',
-            mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1),
-                                        np.arange(2.5, 3.5, 0.25))[0] == 0.))
-    assert (ss[2, 5] <= 1e-15)
-    assert not np.allclose(ss, 0.)
-    z, ss = uk.execute('grid', [1., 2., 3.], [1., 2., 3.], backend='loop')
-    assert z[0, 0] == approx(2.0)
-    assert ss[0, 0] == approx(0.0)
-    assert z[1, 1] == approx(1.5)
-    assert ss[1, 1] == approx(0.0)
-    assert z[2, 2] == approx(1.0)
-    assert ss[2, 2] == approx(0.0)
-    assert ss[0, 2] != approx(0.0)
-    assert ss[2, 0] != approx(0.0)
-    z, ss = uk.execute('points', [1., 2., 3., 3.], [2., 1., 1., 3.],
-                       backend='loop')
+        "points", [1.0, 2.0, 3.0, 3.0], [2.0, 1.0, 1.0, 3.0], backend="vectorized"
+    )
     assert ss[0] != approx(0.0)
     assert ss[1] != approx(0.0)
     assert ss[2] != approx(0.0)
     assert z[3] == approx(1.0)
     assert ss[3] == approx(0.0)
-    z, ss = uk.execute('grid', np.arange(0., 4., 0.1),
-                       np.arange(0., 4., 0.1), backend='loop')
-    assert z[10, 10] == approx(2.)
-    assert ss[10, 10] == approx(0.)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 4.0, 0.1), np.arange(0.0, 4.0, 0.1), backend="vectorized"
+    )
+    assert z[10, 10] == approx(2.0)
+    assert ss[10, 10] == approx(0.0)
     assert z[20, 20] == approx(1.5)
-    assert ss[20, 20] == approx(0.)
+    assert ss[20, 20] == approx(0.0)
     assert z[30, 30] == approx(1.0)
-    assert ss[30, 30] == approx(0.)
+    assert ss[30, 30] == approx(0.0)
     assert ss[0, 0] != approx(0.0)
     assert ss[15, 15] != approx(0.0)
     assert ss[10, 0] != approx(0.0)
@@ -1234,77 +1479,175 @@ def test_force_exact():
     assert ss[10, 20] != approx(0.0)
     assert ss[30, 20] != approx(0.0)
     assert ss[20, 30] != approx(0.0)
-    z, ss = uk.execute('grid', np.arange(0., 3.1, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='loop')
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
+    )
     assert np.any(ss <= 1e-15)
     assert not np.any(ss[:9, :30] <= 1e-15)
-    assert not np.allclose(z[:9, :30], 0.)
-    z, ss = uk.execute('grid', np.arange(0., 1.9, 0.1),
-                       np.arange(2.1, 3.1, 0.1), backend='loop')
-    assert not np.any(ss <= 1e-15)
-    z, ss = uk.execute('masked', np.arange(2.5, 3.5, 0.1),
-                       np.arange(2.5, 3.5, 0.25), backend='loop',
-                       mask=np.asarray(np.meshgrid(np.arange(2.5, 3.5, 0.1),
-                                       np.arange(2.5, 3.5, 0.25))[0] == 0.))
+    assert not np.allclose(z[:9, :30], 0.0)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
+    )
+    assert not (np.any(ss <= 1e-15))
+    z, ss = uk.execute(
+        "masked",
+        np.arange(2.5, 3.5, 0.1),
+        np.arange(2.5, 3.5, 0.25),
+        backend="vectorized",
+        mask=np.asarray(
+            np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
+        ),
+    )
     assert ss[2, 5] <= 1e-15
-    assert not np.allclose(ss, 0.)
+    assert not np.allclose(ss, 0.0)
+    z, ss = uk.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="loop")
+    assert z[0, 0] == approx(2.0)
+    assert ss[0, 0] == approx(0.0)
+    assert z[1, 1] == approx(1.5)
+    assert ss[1, 1] == approx(0.0)
+    assert z[2, 2] == approx(1.0)
+    assert ss[2, 2] == approx(0.0)
+    assert ss[0, 2] != approx(0.0)
+    assert ss[2, 0] != approx(0.0)
+    z, ss = uk.execute(
+        "points", [1.0, 2.0, 3.0, 3.0], [2.0, 1.0, 1.0, 3.0], backend="loop"
+    )
+    assert ss[0] != approx(0.0)
+    assert ss[1] != approx(0.0)
+    assert ss[2] != approx(0.0)
+    assert z[3] == approx(1.0)
+    assert ss[3] == approx(0.0)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 4.0, 0.1), np.arange(0.0, 4.0, 0.1), backend="loop"
+    )
+    assert z[10, 10] == approx(2.0)
+    assert ss[10, 10] == approx(0.0)
+    assert z[20, 20] == approx(1.5)
+    assert ss[20, 20] == approx(0.0)
+    assert z[30, 30] == approx(1.0)
+    assert ss[30, 30] == approx(0.0)
+    assert ss[0, 0] != approx(0.0)
+    assert ss[15, 15] != approx(0.0)
+    assert ss[10, 0] != approx(0.0)
+    assert ss[0, 10] != approx(0.0)
+    assert ss[20, 10] != approx(0.0)
+    assert ss[10, 20] != approx(0.0)
+    assert ss[30, 20] != approx(0.0)
+    assert ss[20, 30] != approx(0.0)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
+    )
+    assert np.any(ss <= 1e-15)
+    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert not np.allclose(z[:9, :30], 0.0)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
+    )
+    assert not np.any(ss <= 1e-15)
+    z, ss = uk.execute(
+        "masked",
+        np.arange(2.5, 3.5, 0.1),
+        np.arange(2.5, 3.5, 0.25),
+        backend="loop",
+        mask=np.asarray(
+            np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
+        ),
+    )
+    assert ss[2, 5] <= 1e-15
+    assert not np.allclose(ss, 0.0)
 
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T,
-                        data[:, 2], np.array([1., 1.]),
-                        variogram_models.linear_variogram_model, [1.0, 1.0],
-                        'euclidean')
-    assert z == approx(2.)
-    assert ss == approx(0.)
-    z, ss = core._krige(np.vstack((data[:, 0], data[:, 1])).T,
-                        data[:, 2], np.array([1., 2.]),
-                        variogram_models.linear_variogram_model, [1.0, 1.0],
-                        'euclidean')
-    assert ss != approx(0.)
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1])).T,
+        data[:, 2],
+        np.array([1.0, 1.0]),
+        variogram_models.linear_variogram_model,
+        [1.0, 1.0],
+        "euclidean",
+    )
+    assert z == approx(2.0)
+    assert ss == approx(0.0)
+    z, ss = core._krige(
+        np.vstack((data[:, 0], data[:, 1])).T,
+        data[:, 2],
+        np.array([1.0, 2.0]),
+        variogram_models.linear_variogram_model,
+        [1.0, 1.0],
+        "euclidean",
+    )
+    assert ss != approx(0.0)
 
     data = np.zeros((50, 3))
-    x, y = np.meshgrid(np.arange(0., 10., 1.), np.arange(0., 10., 2.))
+    x, y = np.meshgrid(np.arange(0.0, 10.0, 1.0), np.arange(0.0, 10.0, 2.0))
     data[:, 0] = np.ravel(x)
     data[:, 1] = np.ravel(y)
     data[:, 2] = np.ravel(x) * np.ravel(y)
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear',
-                         variogram_parameters=[100.0, 1.0])
-    z, ss = ok.execute('grid', np.arange(0., 10., 1.),
-                       np.arange(0., 10., 2.), backend='vectorized')
+    ok = OrdinaryKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        variogram_parameters=[100.0, 1.0],
+    )
+    z, ss = ok.execute(
+        "grid",
+        np.arange(0.0, 10.0, 1.0),
+        np.arange(0.0, 10.0, 2.0),
+        backend="vectorized",
+    )
     assert_allclose(np.ravel(z), data[:, 2], **allclose_pars)
-    assert_allclose(ss, 0., **allclose_pars)
-    z, ss = ok.execute('grid', np.arange(0.5, 10., 1.),
-                       np.arange(0.5, 10., 2.), backend='vectorized')
+    assert_allclose(ss, 0.0, **allclose_pars)
+    z, ss = ok.execute(
+        "grid",
+        np.arange(0.5, 10.0, 1.0),
+        np.arange(0.5, 10.0, 2.0),
+        backend="vectorized",
+    )
     assert not np.allclose(np.ravel(z), data[:, 2])
-    assert not np.allclose(ss, 0.)
-    z, ss = ok.execute('grid', np.arange(0., 10., 1.),
-                       np.arange(0., 10., 2.), backend='loop')
+    assert not np.allclose(ss, 0.0)
+    z, ss = ok.execute(
+        "grid", np.arange(0.0, 10.0, 1.0), np.arange(0.0, 10.0, 2.0), backend="loop"
+    )
     assert_allclose(np.ravel(z), data[:, 2], **allclose_pars)
-    assert_allclose(ss, 0., **allclose_pars)
-    z, ss = ok.execute('grid', np.arange(0.5, 10., 1.),
-                       np.arange(0.5, 10., 2.), backend='loop')
+    assert_allclose(ss, 0.0, **allclose_pars)
+    z, ss = ok.execute(
+        "grid", np.arange(0.5, 10.0, 1.0), np.arange(0.5, 10.0, 2.0), backend="loop"
+    )
     assert not np.allclose(np.ravel(z), data[:, 2])
-    assert not np.allclose(ss, 0.)
+    assert not np.allclose(ss, 0.0)
 
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='linear',
-                          variogram_parameters=[100.0, 1.0])
-    z, ss = uk.execute('grid', np.arange(0., 10., 1.),
-                       np.arange(0., 10., 2.), backend='vectorized')
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="linear",
+        variogram_parameters=[100.0, 1.0],
+    )
+    z, ss = uk.execute(
+        "grid",
+        np.arange(0.0, 10.0, 1.0),
+        np.arange(0.0, 10.0, 2.0),
+        backend="vectorized",
+    )
     assert_allclose(np.ravel(z), data[:, 2], **allclose_pars)
-    assert_allclose(ss, 0., **allclose_pars)
-    z, ss = uk.execute('grid', np.arange(0.5, 10., 1.),
-                       np.arange(0.5, 10., 2.), backend='vectorized')
+    assert_allclose(ss, 0.0, **allclose_pars)
+    z, ss = uk.execute(
+        "grid",
+        np.arange(0.5, 10.0, 1.0),
+        np.arange(0.5, 10.0, 2.0),
+        backend="vectorized",
+    )
     assert not np.allclose(np.ravel(z), data[:, 2])
-    assert not np.allclose(ss, 0.)
-    z, ss = uk.execute('grid', np.arange(0., 10., 1.),
-                       np.arange(0., 10., 2.), backend='loop')
+    assert not np.allclose(ss, 0.0)
+    z, ss = uk.execute(
+        "grid", np.arange(0.0, 10.0, 1.0), np.arange(0.0, 10.0, 2.0), backend="loop"
+    )
     assert_allclose(np.ravel(z), data[:, 2], **allclose_pars)
-    assert_allclose(ss, 0., **allclose_pars)
-    z, ss = uk.execute('grid', np.arange(0.5, 10., 1.),
-                       np.arange(0.5, 10., 2.), backend='loop')
+    assert_allclose(ss, 0.0, **allclose_pars)
+    z, ss = uk.execute(
+        "grid", np.arange(0.5, 10.0, 1.0), np.arange(0.5, 10.0, 2.0), backend="loop"
+    )
     assert not np.allclose(np.ravel(z), data[:, 2])
-    assert not np.allclose(ss, 0.)
+    assert not np.allclose(ss, 0.0)
 
 
 def test_custom_variogram(sample_data_2d):
@@ -1314,51 +1657,74 @@ def test_custom_variogram(sample_data_2d):
         return params[0] * np.log10(dist + params[1]) + params[2]
 
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='mrow')
+        UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="mrow")
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='custom')
+        UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="custom")
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='custom', variogram_function=0)
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="custom",
+            variogram_function=0,
+        )
     with pytest.raises(ValueError):
-        UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='custom', variogram_function=func)
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='custom',
-                          variogram_parameters=[1., 1., 1.],
-                          variogram_function=func)
-    assert uk.variogram_function([1., 1., 1.], 1.) == approx(1.3010, rel=1e-4)
-    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2],
-                          variogram_model='linear')
-    uk.update_variogram_model('custom', variogram_parameters=[1., 1., 1.],
-                              variogram_function=func)
-    assert uk.variogram_function([1., 1., 1.], 1.) == approx(1.3010, rel=1e-4)
+        UniversalKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="custom",
+            variogram_function=func,
+        )
+    uk = UniversalKriging(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="custom",
+        variogram_parameters=[1.0, 1.0, 1.0],
+        variogram_function=func,
+    )
+    assert uk.variogram_function([1.0, 1.0, 1.0], 1.0) == approx(1.3010, rel=1e-4)
+    uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="linear")
+    uk.update_variogram_model(
+        "custom", variogram_parameters=[1.0, 1.0, 1.0], variogram_function=func
+    )
+    assert uk.variogram_function([1.0, 1.0, 1.0], 1.0) == approx(1.3010, rel=1e-4)
 
     with pytest.raises(ValueError):
-        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                        variogram_model='mrow')
+        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="mrow")
     with pytest.raises(ValueError):
-        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                        variogram_model='custom')
+        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="custom")
     with pytest.raises(ValueError):
-        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                        variogram_model='custom', variogram_function=0)
+        OrdinaryKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="custom",
+            variogram_function=0,
+        )
     with pytest.raises(ValueError):
-        OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                        variogram_model='custom', variogram_function=func)
+        OrdinaryKriging(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_model="custom",
+            variogram_function=func,
+        )
     ok = OrdinaryKriging(
-            data[:, 0], data[:, 1], data[:, 2],
-            variogram_model='custom', variogram_parameters=[1., 1., 1.],
-            variogram_function=func)
-    assert ok.variogram_function([1., 1., 1.], 1.) == approx(1.3010, rel=1e-4)
-    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2],
-                         variogram_model='linear')
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        variogram_model="custom",
+        variogram_parameters=[1.0, 1.0, 1.0],
+        variogram_function=func,
+    )
+    assert ok.variogram_function([1.0, 1.0, 1.0], 1.0) == approx(1.3010, rel=1e-4)
+    ok = OrdinaryKriging(data[:, 0], data[:, 1], data[:, 2], variogram_model="linear")
     ok.update_variogram_model(
-            'custom', variogram_parameters=[1., 1., 1.],
-            variogram_function=func)
-    assert ok.variogram_function([1., 1., 1.], 1.) == approx(1.3010, rel=1e-4)
+        "custom", variogram_parameters=[1.0, 1.0, 1.0], variogram_function=func
+    )
+    assert ok.variogram_function([1.0, 1.0, 1.0], 1.0) == approx(1.3010, rel=1e-4)
 
 
 def test_ok3d(validation_ref):
@@ -1368,37 +1734,52 @@ def test_ok3d(validation_ref):
     # Test to compare K3D results to those obtained using KT3D_H2O.
     # (M. Karanovic, M. Tonkin, and D. Wilson, 2009, Groundwater, vol. 47,
     # no. 4, 580-586.)
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], np.zeros(data[:, 1].shape),
-                            data[:, 2], variogram_model='exponential',
-                            variogram_parameters=[500.0, 3000.0, 0.0])
-    k, ss = k3d.execute('grid', gridx_ref, gridy_ref, np.array([0.]),
-                        backend='vectorized')
+    k3d = OrdinaryKriging3D(
+        data[:, 0],
+        data[:, 1],
+        np.zeros(data[:, 1].shape),
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+    )
+    k, ss = k3d.execute(
+        "grid", gridx_ref, gridy_ref, np.array([0.0]), backend="vectorized"
+    )
     assert_allclose(np.squeeze(k), ok_test_answer)
-    k, ss = k3d.execute('grid', gridx_ref, gridy_ref, np.array([0.]),
-                        backend='loop')
+    k, ss = k3d.execute("grid", gridx_ref, gridy_ref, np.array([0.0]), backend="loop")
     assert_allclose(np.squeeze(k), ok_test_answer)
 
     # Test to compare K3D results to those obtained using KT3D.
     data = np.genfromtxt(
-            os.path.join(BASE_DIR, 'test_data', 'test3d_data.txt'),
-            skip_header=1)
-    ans = np.genfromtxt(
-            os.path.join(BASE_DIR, 'test_data', 'test3d_answer.txt'))
+        os.path.join(BASE_DIR, "test_data", "test3d_data.txt"), skip_header=1
+    )
+    ans = np.genfromtxt(os.path.join(BASE_DIR, "test_data", "test3d_answer.txt"))
     ans_z = ans[:, 0].reshape((10, 10, 10))
     ans_ss = ans[:, 1].reshape((10, 10, 10))
     k3d = OrdinaryKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', variogram_parameters=[1., 0.1])
-    k, ss = k3d.execute('grid', np.arange(10.), np.arange(10.), np.arange(10.),
-                        backend='vectorized')
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.1],
+    )
+    k, ss = k3d.execute(
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="vectorized"
+    )
     assert_allclose(k, ans_z, rtol=1e-3, atol=1e-8)
     assert_allclose(ss, ans_ss, rtol=1e-3, atol=1e-8)
     k3d = OrdinaryKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', variogram_parameters=[1., 0.1])
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.1],
+    )
     k, ss = k3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='loop')
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="loop"
+    )
     assert_allclose(k, ans_z, rtol=1e-3, atol=1e-8)
     assert_allclose(ss, ans_ss, rtol=1e-3, atol=1e-8)
 
@@ -1407,18 +1788,27 @@ def test_ok3d_moving_window():
 
     # Test to compare K3D results to those obtained using KT3D.
     data = np.genfromtxt(
-            os.path.join(BASE_DIR, 'test_data', 'test3d_data.txt'),
-            skip_header=1)
-    ans = np.genfromtxt(
-            os.path.join(BASE_DIR, './test_data/test3d_answer.txt'))
+        os.path.join(BASE_DIR, "test_data", "test3d_data.txt"), skip_header=1
+    )
+    ans = np.genfromtxt(os.path.join(BASE_DIR, "./test_data/test3d_answer.txt"))
     ans_z = ans[:, 0].reshape((10, 10, 10))
     ans_ss = ans[:, 1].reshape((10, 10, 10))
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                            variogram_model='linear',
-                            variogram_parameters=[1., 0.1])
+    k3d = OrdinaryKriging3D(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.1],
+    )
     k, ss = k3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='loop', n_closest_points=10)
+        "grid",
+        np.arange(10.0),
+        np.arange(10.0),
+        np.arange(10.0),
+        backend="loop",
+        n_closest_points=10,
+    )
     assert_allclose(k, ans_z, rtol=1e-3)
     assert_allclose(ss, ans_ss, rtol=1e-3)
 
@@ -1428,51 +1818,73 @@ def test_ok3d_uk3d_and_backends_produce_same_results(validation_ref):
     data, _, (uk_test_answer, gridx_ref, gridy_ref) = validation_ref
 
     ok3d = OrdinaryKriging3D(
-            data[:, 0], data[:, 1], np.zeros(data[:, 1].shape),
-            data[:, 2], variogram_model='exponential',
-            variogram_parameters=[500.0, 3000.0, 0.0])
+        data[:, 0],
+        data[:, 1],
+        np.zeros(data[:, 1].shape),
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+    )
     ok_v, oss_v = ok3d.execute(
-            'grid', gridx_ref, gridy_ref, np.array([0.]), backend='vectorized')
+        "grid", gridx_ref, gridy_ref, np.array([0.0]), backend="vectorized"
+    )
     ok_l, oss_l = ok3d.execute(
-            'grid', gridx_ref, gridy_ref, np.array([0.]), backend='loop')
+        "grid", gridx_ref, gridy_ref, np.array([0.0]), backend="loop"
+    )
 
     uk3d = UniversalKriging3D(
-            data[:, 0], data[:, 1], np.zeros(data[:, 1].shape),
-            data[:, 2], variogram_model='exponential',
-            variogram_parameters=[500., 3000., 0.])
+        data[:, 0],
+        data[:, 1],
+        np.zeros(data[:, 1].shape),
+        data[:, 2],
+        variogram_model="exponential",
+        variogram_parameters=[500.0, 3000.0, 0.0],
+    )
     uk_v, uss_v = uk3d.execute(
-            'grid', gridx_ref, gridy_ref, np.array([0.]), backend='vectorized')
+        "grid", gridx_ref, gridy_ref, np.array([0.0]), backend="vectorized"
+    )
     assert_allclose(uk_v, ok_v)
     uk_l, uss_l = uk3d.execute(
-            'grid', gridx_ref, gridy_ref, np.array([0.]), backend='loop')
+        "grid", gridx_ref, gridy_ref, np.array([0.0]), backend="loop"
+    )
     assert_allclose(uk_l, ok_l)
     assert_allclose(uk_l, uk_v)
     assert_allclose(uss_l, uss_v)
 
     data = np.genfromtxt(
-            os.path.join(BASE_DIR, 'test_data', 'test3d_data.txt'),
-            skip_header=1)
+        os.path.join(BASE_DIR, "test_data", "test3d_data.txt"), skip_header=1
+    )
     ok3d = OrdinaryKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', variogram_parameters=[1., 0.1])
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.1],
+    )
     ok_v, oss_v = ok3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='vectorized')
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="vectorized"
+    )
     ok_l, oss_l = ok3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='loop')
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="loop"
+    )
 
     uk3d = UniversalKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', variogram_parameters=[1., 0.1])
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        variogram_parameters=[1.0, 0.1],
+    )
     uk_v, uss_v = uk3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='vectorized')
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="vectorized"
+    )
     assert_allclose(uk_v, ok_v)
     assert_allclose(uss_v, oss_v)
     uk_l, uss_l = uk3d.execute(
-            'grid', np.arange(10.), np.arange(10.), np.arange(10.),
-            backend='loop')
+        "grid", np.arange(10.0), np.arange(10.0), np.arange(10.0), backend="loop"
+    )
     assert_allclose(uk_l, ok_l)
     assert_allclose(uss_l, oss_l)
     assert_allclose(uk_l, uk_v)
@@ -1484,11 +1896,11 @@ def test_ok3d_update_variogram_model(sample_data_3d):
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
     with pytest.raises(ValueError):
-        OrdinaryKriging3D(data[:, 0], data[:, 1],
-                          data[:, 2], data[:, 3], variogram_model='blurg')
+        OrdinaryKriging3D(
+            data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="blurg"
+        )
 
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1],
-                            data[:, 2], data[:, 3])
+    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3])
     variogram_model = k3d.variogram_model
     variogram_parameters = k3d.variogram_model_parameters
     anisotropy_scaling_y = k3d.anisotropy_scaling_y
@@ -1498,11 +1910,15 @@ def test_ok3d_update_variogram_model(sample_data_3d):
     anisotropy_angle_z = k3d.anisotropy_angle_z
 
     with pytest.raises(ValueError):
-        k3d.update_variogram_model('blurg')
+        k3d.update_variogram_model("blurg")
     k3d.update_variogram_model(
-            'power', anisotropy_scaling_y=3.0, anisotropy_scaling_z=3.0,
-            anisotropy_angle_x=45.0, anisotropy_angle_y=45.0,
-            anisotropy_angle_z=45.0)
+        "power",
+        anisotropy_scaling_y=3.0,
+        anisotropy_scaling_z=3.0,
+        anisotropy_angle_x=45.0,
+        anisotropy_angle_y=45.0,
+        anisotropy_angle_z=45.0,
+    )
     assert variogram_model != k3d.variogram_model
     assert variogram_parameters != k3d.variogram_model_parameters
     assert anisotropy_scaling_y != k3d.anisotropy_scaling_y
@@ -1517,11 +1933,11 @@ def test_uk3d_update_variogram_model(sample_data_3d):
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
     with pytest.raises(ValueError):
-        UniversalKriging3D(data[:, 0], data[:, 1],
-                           data[:, 2], data[:, 3], variogram_model='blurg')
+        UniversalKriging3D(
+            data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="blurg"
+        )
 
-    uk3d = UniversalKriging3D(data[:, 0], data[:, 1],
-                              data[:, 2], data[:, 3])
+    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3])
     variogram_model = uk3d.variogram_model
     variogram_parameters = uk3d.variogram_model_parameters
     anisotropy_scaling_y = uk3d.anisotropy_scaling_y
@@ -1531,11 +1947,15 @@ def test_uk3d_update_variogram_model(sample_data_3d):
     anisotropy_angle_z = uk3d.anisotropy_angle_z
 
     with pytest.raises(ValueError):
-        uk3d.update_variogram_model('blurg')
+        uk3d.update_variogram_model("blurg")
     uk3d.update_variogram_model(
-            'power', anisotropy_scaling_y=3.0,
-            anisotropy_scaling_z=3.0, anisotropy_angle_x=45.0,
-            anisotropy_angle_y=45.0, anisotropy_angle_z=45.0)
+        "power",
+        anisotropy_scaling_y=3.0,
+        anisotropy_scaling_z=3.0,
+        anisotropy_angle_x=45.0,
+        anisotropy_angle_y=45.0,
+        anisotropy_angle_z=45.0,
+    )
     assert not variogram_model == uk3d.variogram_model
     assert not variogram_parameters == uk3d.variogram_model_parameters
     assert not anisotropy_scaling_y == uk3d.anisotropy_scaling_y
@@ -1549,12 +1969,15 @@ def test_ok3d_backends_produce_same_result(sample_data_3d):
 
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2],
-                            data[:, 3], variogram_model='linear')
-    k_k3d_v, ss_k3d_v = k3d.execute('grid', gridx_ref, gridy_ref, gridz_ref,
-                                    backend='vectorized')
-    k_k3d_l, ss_k3d_l = k3d.execute('grid', gridx_ref, gridy_ref, gridz_ref,
-                                    backend='loop')
+    k3d = OrdinaryKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
+    k_k3d_v, ss_k3d_v = k3d.execute(
+        "grid", gridx_ref, gridy_ref, gridz_ref, backend="vectorized"
+    )
+    k_k3d_l, ss_k3d_l = k3d.execute(
+        "grid", gridx_ref, gridy_ref, gridz_ref, backend="loop"
+    )
     assert_allclose(k_k3d_v, k_k3d_l, rtol=1e-05, atol=1e-8)
     assert_allclose(ss_k3d_v, ss_k3d_l, rtol=1e-05, atol=1e-8)
 
@@ -1563,15 +1986,12 @@ def test_ok3d_execute(sample_data_3d):
 
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1],
-                            data[:, 2], data[:, 3])
+    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3])
 
     with pytest.raises(ValueError):
-        k3d.execute('blurg', gridx_ref,
-                    gridy_ref, gridz_ref)
+        k3d.execute("blurg", gridx_ref, gridy_ref, gridz_ref)
 
-    k, ss = k3d.execute('grid', gridx_ref, gridy_ref,
-                        gridz_ref, backend='vectorized')
+    k, ss = k3d.execute("grid", gridx_ref, gridy_ref, gridz_ref, backend="vectorized")
     shape = (gridz_ref.size, gridy_ref.size, gridx_ref.size)
     assert k.shape == shape
     assert ss.shape == shape
@@ -1579,8 +1999,7 @@ def test_ok3d_execute(sample_data_3d):
     assert np.amax(ss) != np.amin(ss)
     assert not np.ma.is_masked(k)
 
-    k, ss = k3d.execute('grid', gridx_ref, gridy_ref,
-                        gridz_ref, backend='loop')
+    k, ss = k3d.execute("grid", gridx_ref, gridy_ref, gridz_ref, backend="loop")
     shape = (gridz_ref.size, gridy_ref.size, gridx_ref.size)
     assert k.shape == shape
     assert ss.shape == shape
@@ -1589,112 +2008,141 @@ def test_ok3d_execute(sample_data_3d):
     assert not np.ma.is_masked(k)
 
     with pytest.raises(IOError):
-        k3d.execute('masked', gridx_ref, gridy_ref,
-                    gridz_ref, backend='vectorized')
+        k3d.execute("masked", gridx_ref, gridy_ref, gridz_ref, backend="vectorized")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        k3d.execute('masked', gridx_ref, gridy_ref,
-                    gridz_ref, mask=mask, backend='vectorized')
-    k, ss = k3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                        mask=mask_ref, backend='vectorized')
-    assert (np.ma.is_masked(k))
-    assert (np.ma.is_masked(ss))
+        k3d.execute(
+            "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask, backend="vectorized"
+        )
+    k, ss = k3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref, backend="vectorized"
+    )
+    assert np.ma.is_masked(k)
+    assert np.ma.is_masked(ss)
     assert k[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
-    z, ss = k3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                        mask=mask_ref.T, backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = k3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref.T, backend="vectorized"
+    )
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
 
     with pytest.raises(IOError):
-        k3d.execute('masked', gridx_ref, gridy_ref,
-                    gridz_ref, backend='loop')
+        k3d.execute("masked", gridx_ref, gridy_ref, gridz_ref, backend="loop")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        k3d.execute('masked', gridx_ref, gridy_ref,
-                    gridz_ref, mask=mask, backend='loop')
-    k, ss = k3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                        mask=mask_ref, backend='loop')
-    assert (np.ma.is_masked(k))
-    assert (np.ma.is_masked(ss))
+        k3d.execute(
+            "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask, backend="loop"
+        )
+    k, ss = k3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref, backend="loop"
+    )
+    assert np.ma.is_masked(k)
+    assert np.ma.is_masked(ss)
     assert k[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
-    z, ss = k3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                        mask=mask_ref.T, backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = k3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref.T, backend="loop"
+    )
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
 
     with pytest.raises(ValueError):
-        k3d.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                    np.array([1.0]), backend='vectorized')
-    k, ss = k3d.execute('points', gridx_ref[0], gridy_ref[0],
-                        gridz_ref[0], backend='vectorized')
+        k3d.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            np.array([1.0]),
+            backend="vectorized",
+        )
+    k, ss = k3d.execute(
+        "points", gridx_ref[0], gridy_ref[0], gridz_ref[0], backend="vectorized"
+    )
     assert k.shape == (1,)
     assert ss.shape == (1,)
 
     with pytest.raises(ValueError):
-        k3d.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                    np.array([1.0]), backend='loop')
-    k, ss = k3d.execute('points', gridx_ref[0], gridy_ref[0],
-                        gridz_ref[0], backend='loop')
+        k3d.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            np.array([1.0]),
+            backend="loop",
+        )
+    k, ss = k3d.execute(
+        "points", gridx_ref[0], gridy_ref[0], gridz_ref[0], backend="loop"
+    )
     assert k.shape == (1,)
     assert ss.shape == (1,)
 
     data = np.zeros((125, 4))
-    z, y, x = np.meshgrid(np.arange(0., 5., 1.),
-                          np.arange(0., 5., 1.), np.arange(0., 5., 1.))
+    z, y, x = np.meshgrid(
+        np.arange(0.0, 5.0, 1.0), np.arange(0.0, 5.0, 1.0), np.arange(0.0, 5.0, 1.0)
+    )
     data[:, 0] = np.ravel(x)
     data[:, 1] = np.ravel(y)
     data[:, 2] = np.ravel(z)
     data[:, 3] = np.ravel(z)
     k3d = OrdinaryKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear')
-    k, ss = k3d.execute('grid', np.arange(2., 3., 0.1), np.arange(2., 3., 0.1),
-                        np.arange(0., 4., 1.), backend='vectorized')
-    assert_allclose(k[0, :, :], 0., atol=0.01)
-    assert_allclose(k[1, :, :], 1., rtol=1.e-2)
-    assert_allclose(k[2, :, :], 2., rtol=1.e-2)
-    assert_allclose(k[3, :, :], 3., rtol=1.e-2)
-    k, ss = k3d.execute('grid', np.arange(2., 3., 0.1), np.arange(2., 3., 0.1),
-                        np.arange(0., 4., 1.), backend='loop')
-    assert_allclose(k[0, :, :], 0., atol=0.01)
-    assert_allclose(k[1, :, :], 1., rtol=1.e-2)
-    assert_allclose(k[2, :, :], 2., rtol=1.e-2)
-    assert_allclose(k[3, :, :], 3., rtol=1.e-2)
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                            variogram_model='linear')
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
     k, ss = k3d.execute(
-            'points', [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1., 2., 3.],
-            backend='vectorized')
-    assert_allclose(k[0], 1., atol=0.01)
-    assert_allclose(k[1], 2., rtol=1.e-2)
-    assert_allclose(k[2], 3., rtol=1.e-2)
+        "grid",
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(0.0, 4.0, 1.0),
+        backend="vectorized",
+    )
+    assert_allclose(k[0, :, :], 0.0, atol=0.01)
+    assert_allclose(k[1, :, :], 1.0, rtol=1.0e-2)
+    assert_allclose(k[2, :, :], 2.0, rtol=1.0e-2)
+    assert_allclose(k[3, :, :], 3.0, rtol=1.0e-2)
     k, ss = k3d.execute(
-            'points', [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1., 2., 3.],
-            backend='loop')
-    assert_allclose(k[0], 1., atol=0.01)
-    assert_allclose(k[1], 2., rtol=1.e-2)
-    assert_allclose(k[2], 3., rtol=1.e-2)
+        "grid",
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(0.0, 4.0, 1.0),
+        backend="loop",
+    )
+    assert_allclose(k[0, :, :], 0.0, atol=0.01)
+    assert_allclose(k[1, :, :], 1.0, rtol=1.0e-2)
+    assert_allclose(k[2, :, :], 2.0, rtol=1.0e-2)
+    assert_allclose(k[3, :, :], 3.0, rtol=1.0e-2)
+    k3d = OrdinaryKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
+    k, ss = k3d.execute(
+        "points",
+        [2.5, 2.5, 2.5],
+        [2.5, 2.5, 2.5],
+        [1.0, 2.0, 3.0],
+        backend="vectorized",
+    )
+    assert_allclose(k[0], 1.0, atol=0.01)
+    assert_allclose(k[1], 2.0, rtol=1.0e-2)
+    assert_allclose(k[2], 3.0, rtol=1.0e-2)
+    k, ss = k3d.execute(
+        "points", [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1.0, 2.0, 3.0], backend="loop"
+    )
+    assert_allclose(k[0], 1.0, atol=0.01)
+    assert_allclose(k[1], 2.0, rtol=1.0e-2)
+    assert_allclose(k[2], 3.0, rtol=1.0e-2)
 
 
 def test_uk3d_execute(sample_data_3d):
 
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
-    uk3d = UniversalKriging3D(data[:, 0], data[:, 1],
-                              data[:, 2], data[:, 3])
+    uk3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3])
 
     with pytest.raises(ValueError):
-        uk3d.execute('blurg', gridx_ref,
-                     gridy_ref, gridz_ref)
+        uk3d.execute("blurg", gridx_ref, gridy_ref, gridz_ref)
 
-    k, ss = uk3d.execute('grid', gridx_ref, gridy_ref,
-                         gridz_ref, backend='vectorized')
+    k, ss = uk3d.execute("grid", gridx_ref, gridy_ref, gridz_ref, backend="vectorized")
     shape = (gridz_ref.size, gridy_ref.size, gridx_ref.size)
     assert k.shape == shape
     assert ss.shape == shape
@@ -1702,8 +2150,7 @@ def test_uk3d_execute(sample_data_3d):
     assert np.amax(ss) != np.amin(ss)
     assert not np.ma.is_masked(k)
 
-    k, ss = uk3d.execute('grid', gridx_ref, gridy_ref,
-                         gridz_ref, backend='loop')
+    k, ss = uk3d.execute("grid", gridx_ref, gridy_ref, gridz_ref, backend="loop")
     shape = (gridz_ref.size, gridy_ref.size, gridx_ref.size)
     assert k.shape == shape
     assert ss.shape == shape
@@ -1712,107 +2159,141 @@ def test_uk3d_execute(sample_data_3d):
     assert not np.ma.is_masked(k)
 
     with pytest.raises(IOError):
-        uk3d.execute('masked', gridx_ref, gridy_ref,
-                     gridz_ref, backend='vectorized')
+        uk3d.execute("masked", gridx_ref, gridy_ref, gridz_ref, backend="vectorized")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        uk3d.execute('masked', gridx_ref, gridy_ref,
-                     gridz_ref, mask=mask, backend='vectorized')
-    k, ss = uk3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                         mask=mask_ref, backend='vectorized')
-    assert (np.ma.is_masked(k))
-    assert (np.ma.is_masked(ss))
+        uk3d.execute(
+            "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask, backend="vectorized"
+        )
+    k, ss = uk3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref, backend="vectorized"
+    )
+    assert np.ma.is_masked(k)
+    assert np.ma.is_masked(ss)
     assert k[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
-    z, ss = uk3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                         mask=mask_ref.T, backend='vectorized')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = uk3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref.T, backend="vectorized"
+    )
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
 
     with pytest.raises(IOError):
-        uk3d.execute('masked', gridx_ref, gridy_ref,
-                     gridz_ref, backend='loop')
+        uk3d.execute("masked", gridx_ref, gridy_ref, gridz_ref, backend="loop")
     mask = np.array([True, False])
     with pytest.raises(ValueError):
-        uk3d.execute('masked', gridx_ref, gridy_ref,
-                     gridz_ref, mask=mask, backend='loop')
-    k, ss = uk3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                         mask=mask_ref, backend='loop')
-    assert (np.ma.is_masked(k))
-    assert (np.ma.is_masked(ss))
+        uk3d.execute(
+            "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask, backend="loop"
+        )
+    k, ss = uk3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref, backend="loop"
+    )
+    assert np.ma.is_masked(k)
+    assert np.ma.is_masked(ss)
     assert k[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
-    z, ss = uk3d.execute('masked', gridx_ref, gridy_ref, gridz_ref,
-                         mask=mask_ref.T, backend='loop')
-    assert (np.ma.is_masked(z))
-    assert (np.ma.is_masked(ss))
+    z, ss = uk3d.execute(
+        "masked", gridx_ref, gridy_ref, gridz_ref, mask=mask_ref.T, backend="loop"
+    )
+    assert np.ma.is_masked(z)
+    assert np.ma.is_masked(ss)
     assert z[0, 0, 0] is np.ma.masked
     assert ss[0, 0, 0] is np.ma.masked
 
     with pytest.raises(ValueError):
-        uk3d.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                     np.array([1.0]), backend='vectorized')
-    k, ss = uk3d.execute('points', gridx_ref[0], gridy_ref[0],
-                         gridz_ref[0], backend='vectorized')
+        uk3d.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            np.array([1.0]),
+            backend="vectorized",
+        )
+    k, ss = uk3d.execute(
+        "points", gridx_ref[0], gridy_ref[0], gridz_ref[0], backend="vectorized"
+    )
     assert k.shape == (1,)
     assert ss.shape == (1,)
 
     with pytest.raises(ValueError):
-        uk3d.execute('points', np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0]),
-                     np.array([1.0]), backend='loop')
-    k, ss = uk3d.execute('points', gridx_ref[0], gridy_ref[0],
-                         gridz_ref[0], backend='loop')
+        uk3d.execute(
+            "points",
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),
+            np.array([1.0]),
+            backend="loop",
+        )
+    k, ss = uk3d.execute(
+        "points", gridx_ref[0], gridy_ref[0], gridz_ref[0], backend="loop"
+    )
     assert k.shape == (1,)
     assert ss.shape == (1,)
 
     data = np.zeros((125, 4))
-    z, y, x = np.meshgrid(np.arange(0., 5., 1.), np.arange(0., 5., 1.),
-                          np.arange(0., 5., 1.))
+    z, y, x = np.meshgrid(
+        np.arange(0.0, 5.0, 1.0), np.arange(0.0, 5.0, 1.0), np.arange(0.0, 5.0, 1.0)
+    )
     data[:, 0] = np.ravel(x)
     data[:, 1] = np.ravel(y)
     data[:, 2] = np.ravel(z)
     data[:, 3] = np.ravel(z)
-    k3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                             variogram_model='linear')
-    k, ss = k3d.execute('grid', np.arange(2., 3., 0.1), np.arange(2., 3., 0.1),
-                        np.arange(0., 4., 1.), backend='vectorized')
-    assert_allclose(k[0, :, :], 0., atol=0.01)
-    assert_allclose(k[1, :, :], 1., rtol=1.e-2)
-    assert_allclose(k[2, :, :], 2., rtol=1.e-2)
-    assert_allclose(k[3, :, :], 3., rtol=1.e-2)
-    k, ss = k3d.execute('grid', np.arange(2., 3., 0.1), np.arange(2., 3., 0.1),
-                        np.arange(0., 4., 1.), backend='loop')
-    assert_allclose(k[0, :, :], 0., atol=0.01)
-    assert_allclose(k[1, :, :], 1., rtol=1.e-2)
-    assert_allclose(k[2, :, :], 2., rtol=1.e-2)
-    assert_allclose(k[3, :, :], 3., rtol=1.e-2)
-    k3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                             variogram_model='linear')
+    k3d = UniversalKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
     k, ss = k3d.execute(
-            'points', [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1., 2., 3.],
-            backend='vectorized')
-    assert_allclose(k[0], 1., atol=0.01)
-    assert_allclose(k[1], 2., rtol=1.e-2)
-    assert_allclose(k[2], 3., rtol=1.e-2)
+        "grid",
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(0.0, 4.0, 1.0),
+        backend="vectorized",
+    )
+    assert_allclose(k[0, :, :], 0.0, atol=0.01)
+    assert_allclose(k[1, :, :], 1.0, rtol=1.0e-2)
+    assert_allclose(k[2, :, :], 2.0, rtol=1.0e-2)
+    assert_allclose(k[3, :, :], 3.0, rtol=1.0e-2)
     k, ss = k3d.execute(
-            'points', [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1., 2., 3.],
-            backend='loop')
-    assert_allclose(k[0], 1., atol=0.01)
-    assert_allclose(k[1], 2., rtol=1.e-2)
-    assert_allclose(k[2], 3., rtol=1.e-2)
+        "grid",
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(2.0, 3.0, 0.1),
+        np.arange(0.0, 4.0, 1.0),
+        backend="loop",
+    )
+    assert_allclose(k[0, :, :], 0.0, atol=0.01)
+    assert_allclose(k[1, :, :], 1.0, rtol=1.0e-2)
+    assert_allclose(k[2, :, :], 2.0, rtol=1.0e-2)
+    assert_allclose(k[3, :, :], 3.0, rtol=1.0e-2)
+    k3d = UniversalKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
+    k, ss = k3d.execute(
+        "points",
+        [2.5, 2.5, 2.5],
+        [2.5, 2.5, 2.5],
+        [1.0, 2.0, 3.0],
+        backend="vectorized",
+    )
+    assert_allclose(k[0], 1.0, atol=0.01)
+    assert_allclose(k[1], 2.0, rtol=1.0e-2)
+    assert_allclose(k[2], 3.0, rtol=1.0e-2)
+    k, ss = k3d.execute(
+        "points", [2.5, 2.5, 2.5], [2.5, 2.5, 2.5], [1.0, 2.0, 3.0], backend="loop"
+    )
+    assert_allclose(k[0], 1.0, atol=0.01)
+    assert_allclose(k[1], 2.0, rtol=1.0e-2)
+    assert_allclose(k[2], 3.0, rtol=1.0e-2)
 
 
 def test_force_exact_3d(sample_data_3d):
 
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
-    k3d = OrdinaryKriging3D(data[:, 0], data[:, 1], data[:, 2],
-                            data[:, 3], variogram_model='linear')
+    k3d = OrdinaryKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
     k, ss = k3d.execute(
-            'grid', [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3],
-            backend='vectorized')
+        "grid", [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], backend="vectorized"
+    )
     assert k[2, 0, 0] == approx(0.9)
     assert ss[2, 0, 0] == approx(0.0)
     assert k[0, 2, 0] == approx(0.9)
@@ -1823,8 +2304,8 @@ def test_force_exact_3d(sample_data_3d):
     assert ss[0, 0, 0] != approx(0.0)
 
     k, ss = k3d.execute(
-            'grid', [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3],
-            backend='loop')
+        "grid", [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], backend="loop"
+    )
     assert k[2, 0, 0] == approx(0.9)
     assert ss[2, 0, 0] == approx(0.0)
     assert k[0, 2, 0] == approx(0.9)
@@ -1834,11 +2315,12 @@ def test_force_exact_3d(sample_data_3d):
     assert ss[2, 2, 2] != approx(0.0)
     assert ss[0, 0, 0] != approx(0.0)
 
-    k3d = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2],
-                             data[:, 3], variogram_model='linear')
+    k3d = UniversalKriging3D(
+        data[:, 0], data[:, 1], data[:, 2], data[:, 3], variogram_model="linear"
+    )
     k, ss = k3d.execute(
-            'grid', [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3],
-            backend='vectorized')
+        "grid", [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], backend="vectorized"
+    )
     assert k[2, 0, 0] == approx(0.9)
     assert ss[2, 0, 0] == approx(0.0)
     assert k[0, 2, 0] == approx(0.9)
@@ -1849,8 +2331,8 @@ def test_force_exact_3d(sample_data_3d):
     assert ss[0, 0, 0] != approx(0.0)
 
     k, ss = k3d.execute(
-            'grid', [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3],
-            backend='loop')
+        "grid", [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3], backend="loop"
+    )
     assert k[2, 0, 0] == approx(0.9)
     assert ss[2, 0, 0] == approx(0.0)
     assert k[0, 2, 0] == approx(0.9)
@@ -1865,43 +2347,76 @@ def test_uk3d_specified_drift(sample_data_3d):
 
     data, (gridx_ref, gridy_ref, gridz_ref), mask_ref = sample_data_3d
 
-    zg, yg, xg = np.meshgrid(gridz_ref, gridy_ref, gridx_ref, indexing='ij')
+    zg, yg, xg = np.meshgrid(gridz_ref, gridy_ref, gridx_ref, indexing="ij")
 
     with pytest.raises(ValueError):
-        UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                           variogram_model='linear', drift_terms=['specified'])
+        UniversalKriging3D(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_model="linear",
+            drift_terms=["specified"],
+        )
     with pytest.raises(TypeError):
-        UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                           variogram_model='linear',
-                           drift_terms=['specified'],
-                           specified_drift=data[:, 0])
+        UniversalKriging3D(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_model="linear",
+            drift_terms=["specified"],
+            specified_drift=data[:, 0],
+        )
     with pytest.raises(ValueError):
-        UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                           variogram_model='linear', drift_terms=['specified'],
-                           specified_drift=[data[:2, 0]])
+        UniversalKriging3D(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_model="linear",
+            drift_terms=["specified"],
+            specified_drift=[data[:2, 0]],
+        )
 
-    uk_spec = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2],
-                                 data[:, 3], variogram_model='linear',
-                                 drift_terms=['specified'],
-                                 specified_drift=[data[:, 0], data[:, 1],
-                                                  data[:, 2]])
+    uk_spec = UniversalKriging3D(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        drift_terms=["specified"],
+        specified_drift=[data[:, 0], data[:, 1], data[:, 2]],
+    )
     with pytest.raises(ValueError):
         uk_spec.execute(
-                'grid', gridx_ref, gridy_ref, gridz_ref,
-                specified_drift_arrays=[gridx_ref, gridy_ref, gridz_ref])
+            "grid",
+            gridx_ref,
+            gridy_ref,
+            gridz_ref,
+            specified_drift_arrays=[gridx_ref, gridy_ref, gridz_ref],
+        )
     with pytest.raises(TypeError):
-        uk_spec.execute('grid', gridx_ref, gridy_ref, gridz_ref,
-                        specified_drift_arrays=gridx_ref)
+        uk_spec.execute(
+            "grid", gridx_ref, gridy_ref, gridz_ref, specified_drift_arrays=gridx_ref
+        )
     with pytest.raises(ValueError):
-        uk_spec.execute('grid', gridx_ref, gridy_ref, gridz_ref,
-                        specified_drift_arrays=[zg])
-    z_spec, ss_spec = uk_spec.execute('grid', gridx_ref, gridy_ref, gridz_ref,
-                                      specified_drift_arrays=[xg, yg, zg])
+        uk_spec.execute(
+            "grid", gridx_ref, gridy_ref, gridz_ref, specified_drift_arrays=[zg]
+        )
+    z_spec, ss_spec = uk_spec.execute(
+        "grid", gridx_ref, gridy_ref, gridz_ref, specified_drift_arrays=[xg, yg, zg]
+    )
 
-    uk_lin = UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                                variogram_model='linear',
-                                drift_terms=['regional_linear'])
-    z_lin, ss_lin = uk_lin.execute('grid', gridx_ref, gridy_ref, gridz_ref)
+    uk_lin = UniversalKriging3D(
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        drift_terms=["regional_linear"],
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx_ref, gridy_ref, gridz_ref)
 
     assert_allclose(z_spec, z_lin)
     assert_allclose(ss_spec, ss_lin)
@@ -1916,23 +2431,44 @@ def test_uk3d_functional_drift(sample_data_3d):
     func_z = lambda x, y, z: z  # noqa
 
     with pytest.raises(ValueError):
-        UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                           variogram_model='linear',
-                           drift_terms=['functional'])
+        UniversalKriging3D(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_model="linear",
+            drift_terms=["functional"],
+        )
     with pytest.raises(TypeError):
-        UniversalKriging3D(data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-                           variogram_model='linear',
-                           drift_terms=['functional'], functional_drift=func_x)
+        UniversalKriging3D(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_model="linear",
+            drift_terms=["functional"],
+            functional_drift=func_x,
+        )
 
     uk_func = UniversalKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', drift_terms=['functional'],
-            functional_drift=[func_x, func_y, func_z])
-    z_func, ss_func = uk_func.execute('grid', gridx, gridy, gridz)
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        drift_terms=["functional"],
+        functional_drift=[func_x, func_y, func_z],
+    )
+    z_func, ss_func = uk_func.execute("grid", gridx, gridy, gridz)
     uk_lin = UniversalKriging3D(
-            data[:, 0], data[:, 1], data[:, 2], data[:, 3],
-            variogram_model='linear', drift_terms=['regional_linear'])
-    z_lin, ss_lin = uk_lin.execute('grid', gridx, gridy, gridz)
+        data[:, 0],
+        data[:, 1],
+        data[:, 2],
+        data[:, 3],
+        variogram_model="linear",
+        drift_terms=["regional_linear"],
+    )
+    z_lin, ss_lin = uk_lin.execute("grid", gridx, gridy, gridz)
     assert_allclose(z_func, z_lin)
     assert_allclose(ss_func, ss_lin)
 
@@ -1941,7 +2477,7 @@ def test_geometric_code():
 
     # Create selected points distributed across the sphere:
     N = 4
-    lon = np.array([7.0,   7.0,     187.0,  73.231])
+    lon = np.array([7.0, 7.0, 187.0, 73.231])
     lat = np.array([13.23, 13.2301, -13.23, -79.3])
 
     # For the points generated with this reference seed, the distance matrix
@@ -1955,18 +2491,19 @@ def test_geometric_code():
     # >>>   d *= 180.0/np.pi
     # From that distance matrix, the reference values have been obtained.
     d_ref = np.array(
-            [[0.0, 1e-4, 180.0, 98.744848317171801],
-             [1e-4, 0.0, 179.9999, 98.744946828324345],
-             [180.0, 179.9999, 0.0, 81.255151682828213],
-             [98.744848317171801, 98.744946828324345, 81.255151682828213, 0.0]]
-            )
+        [
+            [0.0, 1e-4, 180.0, 98.744848317171801],
+            [1e-4, 0.0, 179.9999, 98.744946828324345],
+            [180.0, 179.9999, 0.0, 81.255151682828213],
+            [98.744848317171801, 98.744946828324345, 81.255151682828213, 0.0],
+        ]
+    )
 
     # Calculate distance matrix using the PyKrige code:
     d = np.zeros((N, N))
     for i in range(N):
         for j in range(N):
-            d[i, j] = core.great_circle_distance(
-                    lon[i], lat[i], lon[j], lat[j])
+            d[i, j] = core.great_circle_distance(lon[i], lat[i], lon[j], lat[j])
 
     # Test agains reference values:
     assert_allclose(d, d_ref)
@@ -1981,36 +2518,45 @@ def test_geometric_code():
     lon_ref = lon
     lat_ref = lat
     for i in range(len(lon_ref)):
-        lon, lat = np.meshgrid(np.linspace(0, 360.0, 20),
-                               np.linspace(-90.0, 90.0, 20))
-        dx = (np.cos(np.pi/180.0*lon)*np.cos(np.pi/180.0*lat) -
-              np.cos(np.pi/180.0*lon_ref[i])*np.cos(np.pi/180.0*lat_ref[i]))
-        dy = (np.sin(np.pi/180.0*lon)*np.cos(np.pi/180.0*lat) -
-              np.sin(np.pi/180.0*lon_ref[i])*np.cos(np.pi/180.0*lat_ref[i]))
-        dz = np.sin(np.pi/180.0*lat) - np.sin(np.pi/180.0*lat_ref[i])
+        lon, lat = np.meshgrid(np.linspace(0, 360.0, 20), np.linspace(-90.0, 90.0, 20))
+        dx = np.cos(np.pi / 180.0 * lon) * np.cos(np.pi / 180.0 * lat) - np.cos(
+            np.pi / 180.0 * lon_ref[i]
+        ) * np.cos(np.pi / 180.0 * lat_ref[i])
+        dy = np.sin(np.pi / 180.0 * lon) * np.cos(np.pi / 180.0 * lat) - np.sin(
+            np.pi / 180.0 * lon_ref[i]
+        ) * np.cos(np.pi / 180.0 * lat_ref[i])
+        dz = np.sin(np.pi / 180.0 * lat) - np.sin(np.pi / 180.0 * lat_ref[i])
         assert_allclose(
             core.great_circle_distance(lon_ref[i], lat_ref[i], lon, lat),
-            core.euclid3_to_great_circle(np.sqrt(dx**2+dy**2+dz**2)),
-            rtol=1e-5)
+            core.euclid3_to_great_circle(np.sqrt(dx ** 2 + dy ** 2 + dz ** 2)),
+            rtol=1e-5,
+        )
 
 
 def test_ok_geographic():
     # Generate random data:
     np.random.seed(89239413)
-    lon = 360.0*np.random.rand(50, 1)
-    lat = 180.0*np.random.rand(50, 1) - 90.0
+    lon = 360.0 * np.random.rand(50, 1)
+    lat = 180.0 * np.random.rand(50, 1) - 90.0
     z = np.random.rand(50, 1)
 
     # Generate grid:
-    grid_lon = 360.0*np.random.rand(120, 1)
-    grid_lat = 180.0*np.random.rand(120, 1) - 90.0
+    grid_lon = 360.0 * np.random.rand(120, 1)
+    grid_lat = 180.0 * np.random.rand(120, 1) - 90.0
 
     # Create ordinary kriging object:
-    OK = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                         enable_plotting=False, coordinates_type='geographic')
+    OK = OrdinaryKriging(
+        lon,
+        lat,
+        z,
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+        coordinates_type="geographic",
+    )
 
     # Execute on grid:
-    z, ss = OK.execute('grid', grid_lon, grid_lat)
+    z, ss = OK.execute("grid", grid_lon, grid_lat)
 
 
 def test_ok_geographic_vs_euclid():
@@ -2022,9 +2568,9 @@ def test_ok_geographic_vs_euclid():
     # (choose maximum 0.01 degrees), the differences due to curvature
     # should be negligible.
     np.random.seed(89239413)
-    from_north = 1e-2*np.random.random(5)
-    lat = 90.0-from_north
-    lon = 360.0*np.random.random(5)
+    from_north = 1e-2 * np.random.random(5)
+    lat = 90.0 - from_north
+    lon = 360.0 * np.random.random(5)
     z = np.random.random(5)
     z -= z.mean()
     x = from_north * np.cos(np.deg2rad(lon))
@@ -2032,11 +2578,15 @@ def test_ok_geographic_vs_euclid():
 
     # Generate grids:
     grid_lon = 360.0 * np.linspace(0, 1, 50)
-    grid_from_north = np.linspace(0,0.01,10)
+    grid_from_north = np.linspace(0, 0.01, 10)
     grid_lat = 90.0 - grid_from_north
-    grid_x = grid_from_north[:,np.newaxis] * np.cos(np.deg2rad(grid_lon[np.newaxis,:]))
-    grid_y = grid_from_north[:,np.newaxis] * np.sin(np.deg2rad(grid_lon[np.newaxis,:]))
-    grid_lon, grid_lat = np.meshgrid(grid_lon, grid_lat, indexing='xy')
+    grid_x = grid_from_north[:, np.newaxis] * np.cos(
+        np.deg2rad(grid_lon[np.newaxis, :])
+    )
+    grid_y = grid_from_north[:, np.newaxis] * np.sin(
+        np.deg2rad(grid_lon[np.newaxis, :])
+    )
+    grid_lon, grid_lat = np.meshgrid(grid_lon, grid_lat, indexing="xy")
 
     # Flatten the grids:
     grid_x = grid_x.flatten()
@@ -2047,71 +2597,98 @@ def test_ok_geographic_vs_euclid():
     # Calculate and compare distance matrices ensuring that that part
     # of the workflow works as intended (tested: 2e-9 is currently the
     # match for this setup):
-    d_eucl = cdist(np.concatenate([x[:,np.newaxis],y[:,np.newaxis]],axis=1),
-                   np.concatenate([grid_x[:,np.newaxis],grid_y[:,np.newaxis]],axis=1))
-    d_geo = core.great_circle_distance(lon[:,np.newaxis], lat[:,np.newaxis],
-                 grid_lon[np.newaxis,:], grid_lat[np.newaxis,:])
-    assert_allclose(d_eucl,d_geo, rtol=2e-9)
+    d_eucl = cdist(
+        np.concatenate([x[:, np.newaxis], y[:, np.newaxis]], axis=1),
+        np.concatenate([grid_x[:, np.newaxis], grid_y[:, np.newaxis]], axis=1),
+    )
+    d_geo = core.great_circle_distance(
+        lon[:, np.newaxis],
+        lat[:, np.newaxis],
+        grid_lon[np.newaxis, :],
+        grid_lat[np.newaxis, :],
+    )
+    assert_allclose(d_eucl, d_geo, rtol=2e-9)
 
     # Create ordinary kriging objects:
-    OK_geo = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                             enable_plotting=False, coordinates_type='geographic')
-    OK_xy = OrdinaryKriging(x, y, z, variogram_model='linear', verbose=False,
-                            enable_plotting=False)
-    OK_wrong = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                               enable_plotting=False)
+    OK_geo = OrdinaryKriging(
+        lon,
+        lat,
+        z,
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+        coordinates_type="geographic",
+    )
+    OK_xy = OrdinaryKriging(
+        x, y, z, variogram_model="linear", verbose=False, enable_plotting=False
+    )
+    OK_wrong = OrdinaryKriging(
+        lon, lat, z, variogram_model="linear", verbose=False, enable_plotting=False
+    )
 
     # Execute on grid:
-    zgeo, ss = OK_geo.execute('points', grid_lon, grid_lat)
-    zxy, ss = OK_xy.execute('points', grid_x, grid_y)
-    zwrong, ss = OK_wrong.execute('points', grid_lon, grid_lat)
+    zgeo, ss = OK_geo.execute("points", grid_lon, grid_lat)
+    zxy, ss = OK_xy.execute("points", grid_x, grid_y)
+    zwrong, ss = OK_wrong.execute("points", grid_lon, grid_lat)
 
     # Assert equivalence / difference (tested: 2e-5 is currently the
     # match for this setup):
     assert_allclose(zgeo, zxy, rtol=2e-5)
     assert not np.any(zgeo == 0)
-    assert np.abs((zgeo-zwrong)/zgeo).max() > 1.0
+    assert np.abs((zgeo - zwrong) / zgeo).max() > 1.0
 
 
 def test_ok_geometric_closest_points():
     # Generate random data:
     np.random.seed(89239413)
-    lon = 360.0*np.random.rand(50, 1)
-    lat = 180.0*np.random.rand(50, 1) - 90.0
+    lon = 360.0 * np.random.rand(50, 1)
+    lat = 180.0 * np.random.rand(50, 1) - 90.0
     z = np.random.rand(50, 1)
 
     # Generate grid:
-    grid_lon = 360.0*np.random.rand(120, 1)
-    grid_lat = 180.0*np.random.rand(120, 1) - 90.0
+    grid_lon = 360.0 * np.random.rand(120, 1)
+    grid_lat = 180.0 * np.random.rand(120, 1) - 90.0
 
     # Create ordinary kriging object:
-    OK = OrdinaryKriging(lon, lat, z, variogram_model='linear', verbose=False,
-                         enable_plotting=False, coordinates_type='geographic')
+    OK = OrdinaryKriging(
+        lon,
+        lat,
+        z,
+        variogram_model="linear",
+        verbose=False,
+        enable_plotting=False,
+        coordinates_type="geographic",
+    )
 
     # Execute on grid:
     with pytest.raises(ValueError):
         # Test OK raising ValueError when closest_points == 1:
-        z, ss = OK.execute('grid', grid_lon, grid_lat, n_closest_points=1,
-                           backend='C')
-    z, ss = OK.execute('grid', grid_lon, grid_lat, n_closest_points=5,
-                       backend='C')
+        z, ss = OK.execute("grid", grid_lon, grid_lat, n_closest_points=1, backend="C")
+    z, ss = OK.execute("grid", grid_lon, grid_lat, n_closest_points=5, backend="C")
+
 
 @pytest.mark.parametrize("model", [OrdinaryKriging, UniversalKriging])
 def test_gstools_variogram(model):
     gstools = pytest.importorskip("gstools")
     # test data
-    data = np.array([[0.3, 1.2, 0.47],
-                     [1.9, 0.6, 0.56],
-                     [1.1, 3.2, 0.74],
-                     [3.3, 4.4, 1.47],
-                     [4.7, 3.8, 1.74]])
+    data = np.array(
+        [
+            [0.3, 1.2, 0.47],
+            [1.9, 0.6, 0.56],
+            [1.1, 3.2, 0.74],
+            [3.3, 4.4, 1.47],
+            [4.7, 3.8, 1.74],
+        ]
+    )
     gridx = np.arange(0.0, 5.5, 0.1)
     gridy = np.arange(0.0, 6.5, 0.1)
     # a GSTools based covariance model
-    cov_model = gstools.Gaussian(dim=2, len_scale=1, anis=.2, angles=-.5, var=.5, nugget=.1)
+    cov_model = gstools.Gaussian(
+        dim=2, len_scale=1, anis=0.2, angles=-0.5, var=0.5, nugget=0.1
+    )
     # create the krige field
     krige = model(data[:, 0], data[:, 1], data[:, 2], cov_model)
-    z1, ss1 = krige.execute('grid', gridx, gridy)
+    z1, ss1 = krige.execute("grid", gridx, gridy)
     # check if the field coincides with the data
     for i in range(5):
         y_id = int(data[i, 1] * 10)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -477,7 +477,7 @@ def test_ok_update_variogram_model(validation_ref):
 
     # TODO: check that new parameters equal to the set parameters
     assert variogram_model != ok.variogram_model
-    assert variogram_parameters != ok.variogram_model_parameters
+    assert not np.array_equal(variogram_parameters, ok.variogram_model_parameters)
     assert anisotropy_scaling != ok.anisotropy_scaling
     assert anisotropy_angle != ok.anisotropy_angle
 
@@ -663,7 +663,7 @@ def test_uk_update_variogram_model(sample_data_2d):
     uk.update_variogram_model("power", anisotropy_scaling=3.0, anisotropy_angle=45.0)
     # TODO: check that the new parameters are equal to the expected ones
     assert variogram_model != uk.variogram_model
-    assert variogram_parameters != uk.variogram_model_parameters
+    assert not np.array_equal(variogram_parameters, uk.variogram_model_parameters)
     assert anisotropy_scaling != uk.anisotropy_scaling
     assert anisotropy_angle != uk.anisotropy_angle
 
@@ -1920,7 +1920,7 @@ def test_ok3d_update_variogram_model(sample_data_3d):
         anisotropy_angle_z=45.0,
     )
     assert variogram_model != k3d.variogram_model
-    assert variogram_parameters != k3d.variogram_model_parameters
+    assert not np.array_equal(variogram_parameters, k3d.variogram_model_parameters)
     assert anisotropy_scaling_y != k3d.anisotropy_scaling_y
     assert anisotropy_scaling_z != k3d.anisotropy_scaling_z
     assert anisotropy_angle_x != k3d.anisotropy_angle_x
@@ -1957,7 +1957,7 @@ def test_uk3d_update_variogram_model(sample_data_3d):
         anisotropy_angle_z=45.0,
     )
     assert not variogram_model == uk3d.variogram_model
-    assert not variogram_parameters == uk3d.variogram_model_parameters
+    assert not np.array_equal(variogram_parameters, uk3d.variogram_model_parameters)
     assert not anisotropy_scaling_y == uk3d.anisotropy_scaling_y
     assert not anisotropy_scaling_z == uk3d.anisotropy_scaling_z
     assert not anisotropy_angle_x == uk3d.anisotropy_angle_x

--- a/tests/test_regression_krige.py
+++ b/tests/test_regression_krige.py
@@ -12,51 +12,58 @@ try:
     from sklearn.ensemble import RandomForestRegressor
     from sklearn.linear_model import LinearRegression
     from pykrige.compat import train_test_split
+
     SKLEARN_INSTALLED = True
 except ImportError:
     SKLEARN_INSTALLED = False
 
 
 def _methods():
-    krige_methods = ['ordinary', 'universal']
-    ml_methods = [SVR(C=0.01),
-                  RandomForestRegressor(min_samples_split=5,
-                                        n_estimators=50),
-                  LinearRegression(),
-                  Lasso(),
-                  ElasticNet()
-                  ]
+    krige_methods = ["ordinary", "universal"]
+    ml_methods = [
+        SVR(C=0.01),
+        RandomForestRegressor(min_samples_split=5, n_estimators=50),
+        LinearRegression(),
+        Lasso(),
+        ElasticNet(),
+    ]
     return product(ml_methods, krige_methods)
 
 
-@pytest.mark.skipif(not SKLEARN_INSTALLED,
-                    reason="requires scikit-learn")
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="requires scikit-learn")
 def test_regression_krige():
     np.random.seed(1)
-    x = np.linspace(-1., 1., 100)
+    x = np.linspace(-1.0, 1.0, 100)
     # create a feature matrix with 5 features
     X = np.tile(x, reps=(5, 1)).T
-    y = 1 + 5*X[:, 0] - 2*X[:, 1] - 2*X[:, 2] + 3*X[:, 3] + 4*X[:, 4] + \
-        2*(np.random.rand(100) - 0.5)
+    y = (
+        1
+        + 5 * X[:, 0]
+        - 2 * X[:, 1]
+        - 2 * X[:, 2]
+        + 3 * X[:, 3]
+        + 4 * X[:, 4]
+        + 2 * (np.random.rand(100) - 0.5)
+    )
 
     # create lat/lon array
-    lon = np.linspace(-180., 180.0, 10)
-    lat = np.linspace(-90., 90., 10)
+    lon = np.linspace(-180.0, 180.0, 10)
+    lat = np.linspace(-90.0, 90.0, 10)
     lon_lat = np.array(list(product(lon, lat)))
 
-    X_train, X_test, y_train, y_test, lon_lat_train, lon_lat_test = \
-        train_test_split(X, y, lon_lat, train_size=0.7, random_state=10)
+    X_train, X_test, y_train, y_test, lon_lat_train, lon_lat_test = train_test_split(
+        X, y, lon_lat, train_size=0.7, random_state=10
+    )
 
     for ml_model, krige_method in _methods():
-        reg_kr_model = RegressionKriging(regression_model=ml_model,
-                                         method=krige_method,
-                                         n_closest_points=2)
+        reg_kr_model = RegressionKriging(
+            regression_model=ml_model, method=krige_method, n_closest_points=2
+        )
         reg_kr_model.fit(X_train, lon_lat_train, y_train)
         assert reg_kr_model.score(X_test, lon_lat_test, y_test) > 0.25
 
 
-@pytest.mark.skipif(not SKLEARN_INSTALLED,
-                    reason="requires scikit-learn")
+@pytest.mark.skipif(not SKLEARN_INSTALLED, reason="requires scikit-learn")
 def test_krige_housing():
     import ssl
     import urllib
@@ -69,25 +76,25 @@ def test_krige_housing():
             housing = fetch_california_housing()
         except PermissionError:
             # This can raise permission error on Appveyor
-            pytest.skip('Failed to load california housing dataset')
+            pytest.skip("Failed to load california housing dataset")
         ssl._create_default_https_context = ssl.create_default_context
 
     # take only first 1000
-    p = housing['data'][:1000, :-2]
-    x = housing['data'][:1000, -2:]
-    target = housing['target'][:1000]
+    p = housing["data"][:1000, :-2]
+    x = housing["data"][:1000, -2:]
+    target = housing["target"][:1000]
 
-    p_train, p_test, y_train, y_test, x_train, x_test = \
-        train_test_split(p, target, x, train_size=0.7,
-                         random_state=10)
+    p_train, p_test, y_train, y_test, x_train, x_test = train_test_split(
+        p, target, x, train_size=0.7, random_state=10
+    )
 
     for ml_model, krige_method in _methods():
 
-        reg_kr_model = RegressionKriging(regression_model=ml_model,
-                                         method=krige_method,
-                                         n_closest_points=2)
+        reg_kr_model = RegressionKriging(
+            regression_model=ml_model, method=krige_method, n_closest_points=2
+        )
         reg_kr_model.fit(p_train, x_train, y_train)
-        if krige_method == 'ordinary':
+        if krige_method == "ordinary":
             assert reg_kr_model.score(p_test, x_test, y_test) > 0.5
         else:
             assert reg_kr_model.score(p_test, x_test, y_test) > 0.0


### PR DESCRIPTION
To be in line with the GeoStat-Framework standards, I reformatted the code base with [black](https://github.com/psf/black) by executing:

    black pykrige/

Also applied to `docs`, `tests` and `examples`.

Included minor updates:
- include GSTools in tests
- adopt GridSearchCV to be future prove
- add black check stage in travis
- update array comparison in tests to be future prove