### PR TITLE
Update variogram_models.py

### DIFF
--- a/pykrige/variogram_models.py
+++ b/pykrige/variogram_models.py
@@ -79,3 +79,12 @@ def hole_effect_variogram_model(m, d):
         psill * (1.0 - (1.0 - d / (range_ / 3.0)) * np.exp(-d / (range_ / 3.0)))
         + nugget
     )
+
+
+def natural_variogram_model(m, d):
+    """Natural/Stable model, m is [psill, range, nugget, alpha]"""
+    psill = float(m[0])
+    range_ = float(m[1])
+    nugget = float(m[2])
+    alpha = float(m[3])
+    return psill * (1.0 - np.exp(-3.0*(d / range_)**alpha)) + nugget


### PR DESCRIPTION
The natural variogram model combines the Gaussian model and the exponential model such that model behaves like an exponential model when alpha=1 and like a Gaussian model when alpha =2. The advantage over the exponential and gaussian model is its better adjustment of smaller lag distances.