### PR TITLE
Use pseudo inverse to prevent singular matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# do not build pull request from base repo twice (only build PRs of forks)
+if: type != pull_request OR fork = true
+
 language: python
 python: 3.8
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ PyKrige
 .. image:: https://coveralls.io/repos/github/GeoStat-Framework/PyKrige/badge.svg?branch=master
    :target: https://coveralls.io/github/GeoStat-Framework/PyKrige?branch=master
 .. image:: https://readthedocs.org/projects/pykrige/badge/?version=stable
-   :target: http://pykrige.readthedocs.io/en/latest/?badge=stable
+   :target: http://pykrige.readthedocs.io/en/stable/?badge=stable
    :alt: Documentation Status
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -25,8 +25,13 @@ Copyright (c) 2015-2020, PyKrige Developers
 import numpy as np
 from scipy.spatial.distance import pdist, squareform, cdist
 from scipy.optimize import least_squares
+import scipy.linalg as spl
+
 
 eps = 1.0e-10  # Cutoff for comparison to zero
+
+
+P_INV = {1: spl.pinv, 2: spl.pinv2, 3: spl.pinvh}
 
 
 def great_circle_distance(lon1, lat1, lon2, lat2):

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -772,7 +772,7 @@ def _krige(
 
     # solve
     if pseudo_inv:
-        res = np.linalg.lstsq(a, b)
+        res = np.linalg.lstsq(a, b, rcond=None)[0]
     else:
         res = np.linalg.solve(a, b)
     zinterp = np.sum(res[:n, 0] * y)

--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -31,7 +31,7 @@ import scipy.linalg as spl
 eps = 1.0e-10  # Cutoff for comparison to zero
 
 
-P_INV = {1: spl.pinv, 2: spl.pinv2, 3: spl.pinvh}
+P_INV = {"pinv": spl.pinv, "pinv2": spl.pinv2, "pinvh": spl.pinvh}
 
 
 def great_circle_distance(lon1, lat1, lon2, lat2):

--- a/pykrige/lib/cok.pyx
+++ b/pykrige/lib/cok.pyx
@@ -39,11 +39,11 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
 
 
     if pars['pseudo_inv']:
-        if pars['pseudo_inv_type'] == 1:
+        if pars['pseudo_inv_type'] == "pinv":
             a_inv = np.asfortranarray(scipy.linalg.pinv(a_all))
-        elif pars['pseudo_inv_type'] == 2:
+        elif pars['pseudo_inv_type'] == "pinv2":
             a_inv = np.asfortranarray(scipy.linalg.pinv2(a_all))
-        elif pars['pseudo_inv_type'] == 3:
+        elif pars['pseudo_inv_type'] == "pinvh":
             a_inv = np.asfortranarray(scipy.linalg.pinvh(a_all))
         else:
             raise ValueError('Unknown pseudo inverse method selected.')

--- a/pykrige/lib/cok.pyx
+++ b/pykrige/lib/cok.pyx
@@ -35,7 +35,7 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
 
     cdef double [::1] variogram_model_parameters = np.asarray(pars['variogram_model_parameters'])
 
-    cdef double [::1,:] a_inv = scipy.linalg.inv(a_all)
+    cdef double [::1,:] a_inv = scipy.linalg.pinvh(a_all)
 
     for i in range(npt):   # same thing as range(npt) if mask is not defined, otherwise take the non masked elements
         if mask[i]:

--- a/pykrige/lib/cok.pyx
+++ b/pykrige/lib/cok.pyx
@@ -35,7 +35,7 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
 
     cdef double [::1] variogram_model_parameters = np.asarray(pars['variogram_model_parameters'])
 
-    cdef double [::1,:] a_inv = np.empty_like(a_all)
+    cdef double [::1,:] a_inv = np.asfortranarray(np.empty_like(a_all))
 
 
     if pars['pseudo_inv']:
@@ -48,7 +48,7 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
         else:
             raise ValueError('Unknown pseudo inverse method selected.')
     else:
-        a_inv = scipy.linalg.inv(a_all)
+        a_inv = np.asfortranarray(scipy.linalg.inv(a_all))
 
 
     for i in range(npt):   # same thing as range(npt) if mask is not defined, otherwise take the non masked elements

--- a/pykrige/lib/cok.pyx
+++ b/pykrige/lib/cok.pyx
@@ -35,7 +35,21 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
 
     cdef double [::1] variogram_model_parameters = np.asarray(pars['variogram_model_parameters'])
 
-    cdef double [::1,:] a_inv = np.asfortranarray(scipy.linalg.pinvh(a_all))
+    cdef double [::1,:] a_inv = np.empty_like(a_all)
+
+
+    if pars['pseudo_inv']:
+        if pars['pseudo_inv_type'] == 1:
+            a_inv = np.asfortranarray(scipy.linalg.pinv(a_all))
+        elif pars['pseudo_inv_type'] == 2:
+            a_inv = np.asfortranarray(scipy.linalg.pinv2(a_all))
+        elif pars['pseudo_inv_type'] == 3:
+            a_inv = np.asfortranarray(scipy.linalg.pinvh(a_all))
+        else:
+            raise ValueError('Unknown pseudo inverse method selected.')
+    else:
+        a_inv = scipy.linalg.inv(a_all)
+
 
     for i in range(npt):   # same thing as range(npt) if mask is not defined, otherwise take the non masked elements
         if mask[i]:

--- a/pykrige/lib/cok.pyx
+++ b/pykrige/lib/cok.pyx
@@ -35,7 +35,7 @@ cpdef _c_exec_loop(double [:, ::1] a_all,
 
     cdef double [::1] variogram_model_parameters = np.asarray(pars['variogram_model_parameters'])
 
-    cdef double [::1,:] a_inv = scipy.linalg.pinvh(a_all)
+    cdef double [::1,:] a_inv = np.asfortranarray(scipy.linalg.pinvh(a_all))
 
     for i in range(npt):   # same thing as range(npt) if mask is not defined, otherwise take the non masked elements
         if mask[i]:

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -601,7 +601,7 @@ class OrdinaryKriging:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -632,7 +632,7 @@ class OrdinaryKriging:
         zvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -156,14 +156,14 @@ class OrdinaryKriging:
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: False
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`str`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `1`: use `pinv` from `scipy` which uses `lstsq`
-            * `2`: use `pinv2` from `scipy` which uses `SVD`
-            * `3`: use `pinvh` from `scipy` which uses eigen-values
+            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
+            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
-        Default: `1`
+        Default: `"pinv"`
 
     References
     ----------
@@ -201,13 +201,13 @@ class OrdinaryKriging:
         coordinates_type="euclidean",
         exact_values=True,
         pseudo_inv=False,
-        pseudo_inv_type=1,
+        pseudo_inv_type="pinv",
     ):
         # config the pseudo inverse
         self.pseudo_inv = bool(pseudo_inv)
-        self.pseudo_inv_type = int(pseudo_inv_type)
-        if self.pseudo_inv_type not in [1, 2, 3]:
-            raise ValueError("pseudo inv type needs to be in [1,2,3]")
+        self.pseudo_inv_type = str(pseudo_inv_type)
+        if self.pseudo_inv_type not in P_INV:
+            raise ValueError("pseudo inv type not valid: " + str(pseudo_inv_type))
 
         # set up variogram model and parameters...
         self.variogram_model = variogram_model

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -356,6 +356,7 @@ class OrdinaryKriging:
                 self.variogram_function,
                 self.variogram_model_parameters,
                 self.coordinates_type,
+                self.pseudo_inv,
             )
             self.Q1 = core.calcQ1(self.epsilon)
             self.Q2 = core.calcQ2(self.epsilon)
@@ -527,6 +528,7 @@ class OrdinaryKriging:
             self.variogram_function,
             self.variogram_model_parameters,
             self.coordinates_type,
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -586,7 +586,7 @@ class OrdinaryKriging3D:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -617,7 +617,7 @@ class OrdinaryKriging3D:
         kvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -353,6 +353,7 @@ class OrdinaryKriging3D:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
@@ -535,6 +536,7 @@ class OrdinaryKriging3D:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -167,14 +167,14 @@ class OrdinaryKriging3D:
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: False
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`str`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `1`: use `pinv` from `scipy` which uses `lstsq`
-            * `2`: use `pinv2` from `scipy` which uses `SVD`
-            * `3`: use `pinvh` from `scipy` which uses eigen-values
+            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
+            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
-        Default: `1`
+        Default: `"pinv"`
 
     References
     ----------
@@ -214,13 +214,13 @@ class OrdinaryKriging3D:
         enable_plotting=False,
         exact_values=True,
         pseudo_inv=False,
-        pseudo_inv_type=1,
+        pseudo_inv_type="pinv",
     ):
         # config the pseudo inverse
         self.pseudo_inv = bool(pseudo_inv)
-        self.pseudo_inv_type = int(pseudo_inv_type)
-        if self.pseudo_inv_type not in [1, 2, 3]:
-            raise ValueError("pseudo inv type needs to be in [1,2,3]")
+        self.pseudo_inv_type = str(pseudo_inv_type)
+        if self.pseudo_inv_type not in P_INV:
+            raise ValueError("pseudo inv type not valid: " + str(pseudo_inv_type))
 
         # set up variogram model and parameters...
         self.variogram_model = variogram_model

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -14,7 +14,7 @@ References
 ----------
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
-.. [2] N. Cressie, Statistics for spatial data, 
+.. [2] N. Cressie, Statistics for spatial data,
 (Wiley Series in Probability and Statistics, 1993) 137 p.
 
 Copyright (c) 2015-2020, PyKrige Developers
@@ -30,6 +30,7 @@ from .core import (
     _initialize_variogram_model,
     _make_variogram_parameter_list,
     _find_statistics,
+    P_INV,
 )
 import warnings
 
@@ -154,19 +155,32 @@ class OrdinaryKriging3D:
     enable_plotting : bool, optional
         Enables plotting to display variogram. Default is False (off).
     exact_values : bool, optional
-        If True, interpolation provides input values at input locations. 
-        If False, interpolation accounts for variance/nugget within input 
-        values at input locations and does not behave as an 
+        If True, interpolation provides input values at input locations.
+        If False, interpolation accounts for variance/nugget within input
+        values at input locations and does not behave as an
         exact-interpolator [2]. Note that this only has an effect if
         there is variance/nugget present within the input data since it is
         interpreted as measurement error. If the nugget is zero, the kriged
         field will behave as an exact interpolator.
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
+        Default: False
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
 
     References
     ----------
     .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
-    .. [2] N. Cressie, Statistics for spatial data, 
+    .. [2] N. Cressie, Statistics for spatial data,
        (Wiley Series in Probability and Statistics, 1993) 137 p.
     """
 
@@ -199,7 +213,14 @@ class OrdinaryKriging3D:
         verbose=False,
         enable_plotting=False,
         exact_values=True,
+        pseudo_inv=False,
+        pseudo_inv_type=1,
     ):
+        # config the pseudo inverse
+        self.pseudo_inv = bool(pseudo_inv)
+        self.pseudo_inv_type = int(pseudo_inv_type)
+        if self.pseudo_inv_type not in [1, 2, 3]:
+            raise ValueError("pseudo inv type needs to be in [1,2,3]")
 
         # set up variogram model and parameters...
         self.variogram_model = variogram_model
@@ -604,7 +625,11 @@ class OrdinaryKriging3D:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.pinvh(a)
+        # use the desired method to invert the kriging matrix
+        if self.pseudo_inv:
+            a_inv = P_INV[self.pseudo_inv_type](a)
+        else:
+            a_inv = scipy.linalg.inv(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -635,7 +660,11 @@ class OrdinaryKriging3D:
         kvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.pinvh(a)
+        # use the desired method to invert the kriging matrix
+        if self.pseudo_inv:
+            a_inv = P_INV[self.pseudo_inv_type](a)
+        else:
+            a_inv = scipy.linalg.inv(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -187,14 +187,14 @@ class UniversalKriging:
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: False
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`str`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `1`: use `pinv` from `scipy` which uses `lstsq`
-            * `2`: use `pinv2` from `scipy` which uses `SVD`
-            * `3`: use `pinvh` from `scipy` which uses eigen-values
+            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
+            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
-        Default: `1`
+        Default: `"pinv"`
 
     References
     ----------
@@ -239,13 +239,13 @@ class UniversalKriging:
         enable_plotting=False,
         exact_values=True,
         pseudo_inv=False,
-        pseudo_inv_type=1,
+        pseudo_inv_type="pinv",
     ):
         # config the pseudo inverse
         self.pseudo_inv = bool(pseudo_inv)
-        self.pseudo_inv_type = int(pseudo_inv_type)
-        if self.pseudo_inv_type not in [1, 2, 3]:
-            raise ValueError("pseudo inv type needs to be in [1,2,3]")
+        self.pseudo_inv_type = str(pseudo_inv_type)
+        if self.pseudo_inv_type not in P_INV:
+            raise ValueError("pseudo inv type not valid: " + str(pseudo_inv_type))
 
         # Deal with mutable default argument
         if drift_terms is None:

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -377,6 +377,7 @@ class UniversalKriging:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
@@ -766,6 +767,7 @@ class UniversalKriging:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -877,7 +877,7 @@ class UniversalKriging:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -961,7 +961,7 @@ class UniversalKriging:
         zvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -182,14 +182,14 @@ class UniversalKriging3D:
         kriging matrix. If `True`, this leads to more numerical stability
         and redundant points are averaged. But it can take more time.
         Default: False
-    pseudo_inv_type : :class:`int`, optional
+    pseudo_inv_type : :class:`str`, optional
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
-            * `1`: use `pinv` from `scipy` which uses `lstsq`
-            * `2`: use `pinv2` from `scipy` which uses `SVD`
-            * `3`: use `pinvh` from `scipy` which uses eigen-values
+            * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
+            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
+            * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
-        Default: `1`
+        Default: `"pinv"`
 
     References
     ----------
@@ -234,13 +234,13 @@ class UniversalKriging3D:
         enable_plotting=False,
         exact_values=True,
         pseudo_inv=False,
-        pseudo_inv_type=1,
+        pseudo_inv_type="pinv",
     ):
         # config the pseudo inverse
         self.pseudo_inv = bool(pseudo_inv)
-        self.pseudo_inv_type = int(pseudo_inv_type)
-        if self.pseudo_inv_type not in [1, 2, 3]:
-            raise ValueError("pseudo inv type needs to be in [1,2,3]")
+        self.pseudo_inv_type = str(pseudo_inv_type)
+        if self.pseudo_inv_type not in P_INV:
+            raise ValueError("pseudo inv type not valid: " + str(pseudo_inv_type))
 
         # Deal with mutable default argument
         if drift_terms is None:

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -701,7 +701,7 @@ class UniversalKriging3D:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -770,7 +770,7 @@ class UniversalKriging3D:
         kvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.inv(a)
+        a_inv = scipy.linalg.pinvh(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -14,7 +14,7 @@ References
 ----------
 .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
     Hydrogeology, (Cambridge University Press, 1997) 272 p.
-.. [2] N. Cressie, Statistics for spatial data, 
+.. [2] N. Cressie, Statistics for spatial data,
    (Wiley Series in Probability and Statistics, 1993) 137 p.
 
 Copyright (c) 2015-2020, PyKrige Developers
@@ -29,6 +29,7 @@ from .core import (
     _initialize_variogram_model,
     _make_variogram_parameter_list,
     _find_statistics,
+    P_INV,
 )
 import warnings
 
@@ -169,19 +170,32 @@ class UniversalKriging3D:
     enable_plotting : boolean, optional
         Enables plotting to display variogram. Default is False (off).
     exact_values : bool, optional
-        If True, interpolation provides input values at input locations. 
-        If False, interpolation accounts for variance/nugget within input 
-        values at input locations and does not behave as an 
+        If True, interpolation provides input values at input locations.
+        If False, interpolation accounts for variance/nugget within input
+        values at input locations and does not behave as an
         exact-interpolator [2]. Note that this only has an effect if
         there is variance/nugget present within the input data since it is
         interpreted as measurement error. If the nugget is zero, the kriged
         field will behave as an exact interpolator.
+    pseudo_inv : :class:`bool`, optional
+        Whether the kriging system is solved with the pseudo inverted
+        kriging matrix. If `True`, this leads to more numerical stability
+        and redundant points are averaged. But it can take more time.
+        Default: False
+    pseudo_inv_type : :class:`int`, optional
+        Here you can select the algorithm to compute the pseudo-inverse matrix:
+
+            * `1`: use `pinv` from `scipy` which uses `lstsq`
+            * `2`: use `pinv2` from `scipy` which uses `SVD`
+            * `3`: use `pinvh` from `scipy` which uses eigen-values
+
+        Default: `1`
 
     References
     ----------
     .. [1] P.K. Kitanidis, Introduction to Geostatistcs: Applications in
        Hydrogeology, (Cambridge University Press, 1997) 272 p.
-    .. [2] N. Cressie, Statistics for spatial data, 
+    .. [2] N. Cressie, Statistics for spatial data,
        (Wiley Series in Probability and Statistics, 1993) 137 p.
     """
 
@@ -219,7 +233,14 @@ class UniversalKriging3D:
         verbose=False,
         enable_plotting=False,
         exact_values=True,
+        pseudo_inv=False,
+        pseudo_inv_type=1,
     ):
+        # config the pseudo inverse
+        self.pseudo_inv = bool(pseudo_inv)
+        self.pseudo_inv_type = int(pseudo_inv_type)
+        if self.pseudo_inv_type not in [1, 2, 3]:
+            raise ValueError("pseudo inv type needs to be in [1,2,3]")
 
         # Deal with mutable default argument
         if drift_terms is None:
@@ -719,7 +740,11 @@ class UniversalKriging3D:
         zero_index = None
         zero_value = False
 
-        a_inv = scipy.linalg.pinvh(a)
+        # use the desired method to invert the kriging matrix
+        if self.pseudo_inv:
+            a_inv = P_INV[self.pseudo_inv_type](a)
+        else:
+            a_inv = scipy.linalg.inv(a)
 
         if np.any(np.absolute(bd) <= self.eps):
             zero_value = True
@@ -788,7 +813,11 @@ class UniversalKriging3D:
         kvalues = np.zeros(npt)
         sigmasq = np.zeros(npt)
 
-        a_inv = scipy.linalg.pinvh(a)
+        # use the desired method to invert the kriging matrix
+        if self.pseudo_inv:
+            a_inv = P_INV[self.pseudo_inv_type](a)
+        else:
+            a_inv = scipy.linalg.inv(a)
 
         for j in np.nonzero(~mask)[
             0

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -381,6 +381,7 @@ class UniversalKriging3D:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)
@@ -620,6 +621,7 @@ class UniversalKriging3D:
             self.variogram_function,
             self.variogram_model_parameters,
             "euclidean",
+            self.pseudo_inv,
         )
         self.Q1 = core.calcQ1(self.epsilon)
         self.Q2 = core.calcQ2(self.epsilon)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2897,7 +2897,7 @@ def test_gstools_variogram(model):
 def test_pseudo_2d(model):
     # test data
     data = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 3.0], [1.0, 0.0, 6.0]])
-    for p_type in [1, 2, 3]:
+    for p_type in ["pinv", "pinv2", "pinvh"]:
         # create the krige field
         krige = model(
             data[:, 0],
@@ -2916,7 +2916,7 @@ def test_pseudo_2d(model):
 def test_pseudo_3d(model):
     # test data
     data = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 3.0], [1.0, 0.0, 0.0, 6.0]])
-    for p_type in [1, 2, 3]:
+    for p_type in ["pinv", "pinv2", "pinvh"]:
         # create the krige field
         krige = model(
             data[:, 0],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2891,3 +2891,42 @@ def test_gstools_variogram(model):
         y_id = int(data[i, 1] * 10)
         x_id = int(data[i, 0] * 10)
         assert np.isclose(z1[y_id, x_id], data[i, 2])
+
+
+@pytest.mark.parametrize("model", [OrdinaryKriging, UniversalKriging])
+def test_pseudo_2d(model):
+    # test data
+    data = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 3.0], [1.0, 0.0, 6.0],])
+    for p_type in [1, 2, 3]:
+        # create the krige field
+        krige = model(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            variogram_parameters=[1.0, 0.0],
+            pseudo_inv=True,
+            pseudo_inv_type=p_type,
+        )
+        z1, ss1 = krige.execute("points", 0.0, 0.0)
+        # check if the field coincides with the mean of the redundant data
+        assert np.isclose(z1.item(), 2.0)
+
+
+@pytest.mark.parametrize("model", [OrdinaryKriging3D, UniversalKriging3D])
+def test_pseudo_3d(model):
+    # test data
+    data = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 3.0], [1.0, 0.0, 0.0, 6.0],])
+    for p_type in [1, 2, 3]:
+        # create the krige field
+        krige = model(
+            data[:, 0],
+            data[:, 1],
+            data[:, 2],
+            data[:, 3],
+            variogram_parameters=[1.0, 0.0],
+            pseudo_inv=True,
+            pseudo_inv_type=p_type,
+        )
+        z1, ss1 = krige.execute("points", 0.0, 0.0, 0.0)
+        # check if the field coincides with the mean of the redundant data
+        assert np.isclose(z1.item(), 2.0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2896,7 +2896,7 @@ def test_gstools_variogram(model):
 @pytest.mark.parametrize("model", [OrdinaryKriging, UniversalKriging])
 def test_pseudo_2d(model):
     # test data
-    data = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 3.0], [1.0, 0.0, 6.0],])
+    data = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 3.0], [1.0, 0.0, 6.0]])
     for p_type in [1, 2, 3]:
         # create the krige field
         krige = model(
@@ -2915,7 +2915,7 @@ def test_pseudo_2d(model):
 @pytest.mark.parametrize("model", [OrdinaryKriging3D, UniversalKriging3D])
 def test_pseudo_3d(model):
     # test data
-    data = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 3.0], [1.0, 0.0, 0.0, 6.0],])
+    data = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 3.0], [1.0, 0.0, 0.0, 6.0]])
     for p_type in [1, 2, 3]:
         # create the krige field
         krige = model(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1369,13 +1369,13 @@ def test_force_exact():
     z, ss = ok.execute(
         "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
     )
-    assert np.any(ss <= 1e-15)
-    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert np.any(np.isclose(ss, 0))
+    assert not np.any(np.isclose(ss[:9, :30], 0))
     assert not np.allclose(z[:9, :30], 0.0)
     z, ss = ok.execute(
         "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
     )
-    assert not np.any(ss <= 1e-15)
+    assert not np.any(np.isclose(ss, 0))
     z, ss = ok.execute(
         "masked",
         np.arange(2.5, 3.5, 0.1),
@@ -1385,7 +1385,7 @@ def test_force_exact():
             np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
         ),
     )
-    assert ss[2, 5] <= 1e-15
+    assert np.isclose(ss[2, 5], 0)
     assert not np.allclose(ss, 0.0)
 
     z, ss = ok.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="loop")
@@ -1425,13 +1425,13 @@ def test_force_exact():
     z, ss = ok.execute(
         "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
     )
-    assert np.any(ss <= 1e-15)
-    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert np.any(np.isclose(ss, 0))
+    assert not np.any(np.isclose(ss[:9, :30], 0))
     assert not np.allclose(z[:9, :30], 0.0)
     z, ss = ok.execute(
         "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
     )
-    assert not np.any(ss <= 1e-15)
+    assert not np.any(np.isclose(ss, 0))
     z, ss = ok.execute(
         "masked",
         np.arange(2.5, 3.5, 0.1),
@@ -1441,7 +1441,7 @@ def test_force_exact():
             np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
         ),
     )
-    assert ss[2, 5] <= 1e-15
+    assert np.isclose(ss[2, 5], 0)
     assert not np.allclose(ss, 0.0)
 
     uk = UniversalKriging(data[:, 0], data[:, 1], data[:, 2])
@@ -1482,13 +1482,13 @@ def test_force_exact():
     z, ss = uk.execute(
         "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
     )
-    assert np.any(ss <= 1e-15)
-    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert np.any(np.isclose(ss, 0))
+    assert not np.any(np.isclose(ss[:9, :30], 0))
     assert not np.allclose(z[:9, :30], 0.0)
     z, ss = uk.execute(
         "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="vectorized"
     )
-    assert not (np.any(ss <= 1e-15))
+    assert not (np.any(np.isclose(ss, 0)))
     z, ss = uk.execute(
         "masked",
         np.arange(2.5, 3.5, 0.1),
@@ -1498,7 +1498,7 @@ def test_force_exact():
             np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
         ),
     )
-    assert ss[2, 5] <= 1e-15
+    assert np.isclose(ss[2, 5], 0)
     assert not np.allclose(ss, 0.0)
     z, ss = uk.execute("grid", [1.0, 2.0, 3.0], [1.0, 2.0, 3.0], backend="loop")
     assert z[0, 0] == approx(2.0)
@@ -1537,13 +1537,13 @@ def test_force_exact():
     z, ss = uk.execute(
         "grid", np.arange(0.0, 3.1, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
     )
-    assert np.any(ss <= 1e-15)
-    assert not np.any(ss[:9, :30] <= 1e-15)
+    assert np.any(np.isclose(ss, 0))
+    assert not np.any(np.isclose(ss[:9, :30], 0))
     assert not np.allclose(z[:9, :30], 0.0)
     z, ss = uk.execute(
         "grid", np.arange(0.0, 1.9, 0.1), np.arange(2.1, 3.1, 0.1), backend="loop"
     )
-    assert not np.any(ss <= 1e-15)
+    assert not np.any(np.isclose(ss, 0))
     z, ss = uk.execute(
         "masked",
         np.arange(2.5, 3.5, 0.1),
@@ -1553,7 +1553,7 @@ def test_force_exact():
             np.meshgrid(np.arange(2.5, 3.5, 0.1), np.arange(2.5, 3.5, 0.25))[0] == 0.0
         ),
     )
-    assert ss[2, 5] <= 1e-15
+    assert np.isclose(ss[2, 5], 0)
     assert not np.allclose(ss, 0.0)
 
     z, ss = core._krige(


### PR DESCRIPTION
This is adressing #87, #150 and others.
The pseudo-inverse eventually solves the system by the least square error solution of the kriging equation. This helps to solve over-/under-determined systems.

If there are redundant points, their values will be averaged in the resulting krige field.

This feature can be pluged in via a switch in the init routines of Ordinary and Universal kriging in 2D/3D.