### PR TITLE
Removed pinv2 references for bug fix

### DIFF
--- a/pykrige/core.py
+++ b/pykrige/core.py
@@ -31,7 +31,7 @@ import scipy.linalg as spl
 eps = 1.0e-10  # Cutoff for comparison to zero
 
 
-P_INV = {"pinv": spl.pinv, "pinv2": spl.pinv2, "pinvh": spl.pinvh}
+P_INV = {"pinv": spl.pinv, "pinvh": spl.pinvh}
 
 
 def great_circle_distance(lon1, lat1, lon2, lat2):

--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -160,7 +160,6 @@ class OrdinaryKriging:
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         Default: `"pinv"`

--- a/pykrige/ok3d.py
+++ b/pykrige/ok3d.py
@@ -171,7 +171,6 @@ class OrdinaryKriging3D:
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         Default: `"pinv"`

--- a/pykrige/uk.py
+++ b/pykrige/uk.py
@@ -191,7 +191,6 @@ class UniversalKriging:
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         Default: `"pinv"`

--- a/pykrige/uk3d.py
+++ b/pykrige/uk3d.py
@@ -186,7 +186,6 @@ class UniversalKriging3D:
         Here you can select the algorithm to compute the pseudo-inverse matrix:
 
             * `"pinv"`: use `pinv` from `scipy` which uses `lstsq`
-            * `"pinv2"`: use `pinv2` from `scipy` which uses `SVD`
             * `"pinvh"`: use `pinvh` from `scipy` which uses eigen-values
 
         Default: `"pinv"`

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2951,7 +2951,7 @@ def test_gstools_variogram(model):
 def test_pseudo_2d(model):
     # test data
     data = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 3.0], [1.0, 0.0, 6.0]])
-    for p_type in ["pinv", "pinv2", "pinvh"]:
+    for p_type in ["pinv", "pinvh"]:
         # create the krige field
         krige = model(
             data[:, 0],
@@ -2970,7 +2970,7 @@ def test_pseudo_2d(model):
 def test_pseudo_3d(model):
     # test data
     data = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 3.0], [1.0, 0.0, 0.0, 6.0]])
-    for p_type in ["pinv", "pinv2", "pinvh"]:
+    for p_type in ["pinv", "pinvh"]:
         # create the krige field
         krige = model(
             data[:, 0],


### PR DESCRIPTION
pinv2 was removed by scipy. This was causing the library to crash upon import. Removing references to pinv2 fixes the issue.