### PR TITLE
GSTools: support latlon models for geographic coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ sklearn = ["scikit-learn>=0.19"]
 test = [
     "pytest-cov>=3",
     "scikit-learn>=0.19",
-    # "gstools>=1.3,<2",
+    "gstools>=1.4,<2",
 ]
 
 [project.urls]

--- a/src/pykrige/compat_gstools.py
+++ b/src/pykrige/compat_gstools.py
@@ -9,6 +9,7 @@ try:
     GSTOOLS_INSTALLED = True
     GSTOOLS_VERSION = list(map(int, gs.__version__.split(".")[:2]))
 except ImportError:
+    gs = None
     GSTOOLS_INSTALLED = False
     GSTOOLS_VERSION = None
 

--- a/src/pykrige/compat_gstools.py
+++ b/src/pykrige/compat_gstools.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+# pylint: disable= invalid-name,  unused-import
+"""For GSTools compatibility."""
+
+# gstools
+try:
+    import gstools as gs
+
+    GSTOOLS_INSTALLED = True
+    GSTOOLS_VERSION = list(map(int, gs.__version__.split(".")[:2]))
+except ImportError:
+    GSTOOLS_INSTALLED = False
+    GSTOOLS_VERSION = None
+
+
+class GSToolsException(Exception):
+    """Exception for GSTools."""
+
+
+def validate_gstools(model):
+    """Validate presence of GSTools."""
+    if not GSTOOLS_INSTALLED:
+        raise GSToolsException(
+            "GSTools needs to be installed in order to use their CovModel class."
+        )
+    if not isinstance(model, gs.CovModel):
+        raise GSToolsException(
+            "GSTools: given variogram model is not a CovModel instance."
+        )
+    if GSTOOLS_VERSION < [1, 3]:
+        raise GSToolsException("GSTools: need at least GSTools v1.3.")
+    if model.latlon and GSTOOLS_VERSION < [1, 4]:
+        raise GSToolsException(
+            "GSTools: latlon models in PyKrige are only supported from GSTools v1.4."
+        )

--- a/src/pykrige/ok.py
+++ b/src/pykrige/ok.py
@@ -226,10 +226,9 @@ class OrdinaryKriging:
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             # check if coordinate types match
-            if (self.coordinates_type == "geographic") != self.model.latlon:
+            if self.model.latlon and (self.coordinates_type == "euclidean"):
                 raise ValueError(
-                    "GSTools: latlon models are needed and only valid "
-                    "for geographic coordinates"
+                    "GSTools: latlon models require geographic coordinates"
                 )
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
@@ -432,10 +431,9 @@ class OrdinaryKriging:
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             # check if coordinate types match
-            if (self.coordinates_type == "geographic") != self.model.latlon:
+            if self.model.latlon and (self.coordinates_type == "euclidean"):
                 raise ValueError(
-                    "GSTools: latlon models are needed and only valid "
-                    "for geographic coordinates"
+                    "GSTools: latlon models require geographic coordinates"
                 )
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario

--- a/src/pykrige/ok.py
+++ b/src/pykrige/ok.py
@@ -28,6 +28,7 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 
 from . import core, variogram_models
+from .compat_gstools import validate_gstools
 from .core import (
     P_INV,
     _adjust_for_anisotropy,
@@ -223,6 +224,7 @@ class OrdinaryKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             # check if coordinate types match
@@ -428,6 +430,7 @@ class OrdinaryKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             # check if coordinate types match

--- a/src/pykrige/ok3d.py
+++ b/src/pykrige/ok3d.py
@@ -234,7 +234,7 @@ class OrdinaryKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim < 3:
+            if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
@@ -430,7 +430,7 @@ class OrdinaryKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim < 3:
+            if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario

--- a/src/pykrige/ok3d.py
+++ b/src/pykrige/ok3d.py
@@ -27,6 +27,7 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 
 from . import core, variogram_models
+from .compat_gstools import validate_gstools
 from .core import (
     P_INV,
     _adjust_for_anisotropy,
@@ -234,6 +235,7 @@ class OrdinaryKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
@@ -430,6 +432,7 @@ class OrdinaryKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"

--- a/src/pykrige/uk.py
+++ b/src/pykrige/uk.py
@@ -267,7 +267,7 @@ class UniversalKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim == 3:
+            if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
@@ -673,7 +673,7 @@ class UniversalKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim == 3:
+            if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario

--- a/src/pykrige/uk.py
+++ b/src/pykrige/uk.py
@@ -269,6 +269,10 @@ class UniversalKriging:
             self.model = self.variogram_model
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
+            if self.model.latlon:
+                raise ValueError(
+                    "GSTools: latlon models not supported for universal kriging"
+                )
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
             variogram_parameters = []
@@ -675,6 +679,10 @@ class UniversalKriging:
             self.model = self.variogram_model
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
+            if self.model.latlon:
+                raise ValueError(
+                    "GSTools: latlon models not supported for universal kriging"
+                )
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
             variogram_parameters = []

--- a/src/pykrige/uk.py
+++ b/src/pykrige/uk.py
@@ -26,6 +26,7 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 
 from . import core, variogram_models
+from .compat_gstools import validate_gstools
 from .core import (
     P_INV,
     _adjust_for_anisotropy,
@@ -267,6 +268,7 @@ class UniversalKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             if self.model.latlon:
@@ -677,6 +679,7 @@ class UniversalKriging:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim == 3:
                 raise ValueError("GSTools: model dim is not 1 or 2")
             if self.model.latlon:

--- a/src/pykrige/uk3d.py
+++ b/src/pykrige/uk3d.py
@@ -262,7 +262,7 @@ class UniversalKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim < 3:
+            if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario
@@ -515,7 +515,7 @@ class UniversalKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
-            if self.model.dim < 3:
+            if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
             variogram_function = self.model.pykrige_vario

--- a/src/pykrige/uk3d.py
+++ b/src/pykrige/uk3d.py
@@ -26,6 +26,7 @@ import scipy.linalg
 from scipy.spatial.distance import cdist
 
 from . import core, variogram_models
+from .compat_gstools import validate_gstools
 from .core import (
     P_INV,
     _adjust_for_anisotropy,
@@ -262,6 +263,7 @@ class UniversalKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"
@@ -515,6 +517,7 @@ class UniversalKriging3D:
         if hasattr(self.variogram_model, "pykrige_kwargs"):
             # save the model in the class
             self.model = self.variogram_model
+            validate_gstools(self.model)
             if self.model.field_dim < 3:
                 raise ValueError("GSTools: model dim is not 3")
             self.variogram_model = "custom"


### PR DESCRIPTION
Bugfix to correctly support latlon models from GSTools.

This needs https://github.com/GeoStat-Framework/GSTools/pull/254 to be included in the next GSTools release.