### PR TITLE
Drop Python 3.8, depend on scipy>=1.6.0, test with Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,17 +76,15 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
-          - {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
-          - {py: '3.9', np: '==1.20.0', sp: '==1.5.4'}
+          - {py: '3.9', np: '==1.20.0', sp: '==1.6.3'}
           - {py: '3.10', np: '==1.21.6', sp: '==1.7.2'}
           - {py: '3.11', np: '==1.23.2', sp: '==1.9.2'}
           - {py: '3.12', np: '==1.26.2', sp: '==1.11.2'}
-          - {py: '3.12', np: '>=2.0.0rc1', sp: '>=1.13.0'}
+          - {py: '3.12', np: '>=2.0.0', sp: '>=1.13.0'}
+          - {py: '3.13', np: '>=2.1.0', sp: '>=1.14.1'}
         exclude:
           - os: macos-14
-            ver: {py: '3.8', np: '==1.20.0', sp: '==1.5.4'}
-          - os: macos-14
-            ver: {py: '3.9', np: '==1.20.0', sp: '==1.5.4'}
+            ver: {py: '3.9', np: '==1.20.0', sp: '==1.6.3'}
           - os: macos-14
             ver: {py: '3.10', np: '==1.21.6', sp: '==1.7.2'}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,14 @@
 requires = [
     "setuptools>=64",
     "setuptools_scm>=7",
-    "numpy>=2.0.0rc1,<2.3; python_version >= '3.9'",
-    "scipy>=1.13.0,<2; python_version >= '3.9'",
-    "oldest-supported-numpy; python_version < '3.9'",
-    "scipy>=1.3.2,<2; python_version < '3.9'",
+    "numpy>=2.0.0,<2.3",
+    "scipy>=1.13.0,<2",
     "Cython>=3.0.10,<3.1.0",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 name = "PyKrige"
 description = "Kriging Toolkit for Python."
 authors = [
@@ -36,11 +34,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -49,22 +47,22 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.20.0",
-    "scipy>=1.1.0,<2",
+    "scipy>=1.6.0,<2",
 ]
 
 [project.optional-dependencies]
 doc = [
     "gstools>=1.4,<2",
     "pillow",
-    "scikit-learn>=0.19",
+    "scikit-learn>=0.24",
     "m2r2>=0.2.8",
-    "matplotlib>=3",
-    "numpydoc>=1.1",
+    "matplotlib>=3.4.0",
+    "numpydoc>=1.2",
     "sphinx>=7",
     "sphinx-gallery>=0.8",
     "sphinx-rtd-theme>=2",
 ]
-plot = ["matplotlib>=3,<4"]
+plot = ["matplotlib>=3.4.0,<4"]
 sklearn = ["scikit-learn>=0.19"]
 test = [
     "pytest-cov>=3",
@@ -101,7 +99,6 @@ multi_line_output = 3
 
 [tool.black]
 target-version = [
-    "py38",
     "py39",
     "py310",
     "py311",
@@ -155,8 +152,8 @@ max-line-length = 100
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building PyPy wheels on all platforms, 32bit and musllinux builds, py3.6/7
-skip = ["cp36-*", "cp37-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+# Disable building PyPy wheels on all platforms, 32bit and musllinux builds, py3.6/7/8
+skip = ["cp36-*", "cp37-*", "cp38-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"


### PR DESCRIPTION
Python 3.8 reached it's end-of-life in 2024-10-07 ([PEP 569](https://peps.python.org/pep-0569/)), so should be dropped. Add Python 3.13 to the testing matrix.

Change SciPy dependency to >=[1.6.0](https://pypi.org/project/scipy/1.6.0/) to overlap with Python 3.9. The minimum version of scikit-learn is increased to overlap with Python 3.9.

This PR is similar to https://github.com/GeoStat-Framework/GSTools/pull/386